### PR TITLE
[Feat]: Comment 컨트롤러, DTO, Service, Repo 추가 (불필요한 필드 삭제 / 예외처리 수정)

### DIFF
--- a/src/main/java/com/inconcert/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/inconcert/domain/comment/controller/CommentController.java
@@ -15,15 +15,15 @@ import java.util.List;
 public class CommentController {
     private final CommentService commentService;
 
-    @GetMapping("/{post_id}")
-    public ResponseEntity<List<CommentDto>> getComments(@PathVariable("post_id") Long postId) {
+    @GetMapping("/{postId}")
+    public ResponseEntity<List<CommentDto>> getComments(@PathVariable("postId") Long postId) {
         List<CommentDto> byPostId = commentService.findByPostId(postId);
         return ResponseEntity.ok(byPostId);
     }
 
-    @GetMapping("/{comment_id}")
-    public ResponseEntity<CommentDto> getComment(@PathVariable("comment_id") Long id) {
-        CommentDto commentDto = commentService.findComment(id);
+    @GetMapping("/{commentId}")
+    public ResponseEntity<CommentDto> getComment(@PathVariable("commentId") Long commentId) {
+        CommentDto commentDto = commentService.findComment(commentId);
         return ResponseEntity.ok(commentDto);
     }
 }

--- a/src/main/java/com/inconcert/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/inconcert/domain/comment/controller/CommentController.java
@@ -1,0 +1,29 @@
+package com.inconcert.domain.comment.controller;
+
+import com.inconcert.domain.comment.dto.CommentDto;
+import com.inconcert.domain.comment.service.CommentService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+
+import java.util.List;
+
+@Controller
+@RequiredArgsConstructor
+public class CommentController {
+    private final CommentService commentService;
+
+    @GetMapping("/{post_id}")
+    public ResponseEntity<List<CommentDto>> getComments(@PathVariable("post_id") Long postId) {
+        List<CommentDto> byPostId = commentService.findByPostId(postId);
+        return ResponseEntity.ok(byPostId);
+    }
+
+    @GetMapping("/{comment_id}")
+    public ResponseEntity<CommentDto> getComment(@PathVariable("comment_id") Long id) {
+        CommentDto commentDto = commentService.findComment(id);
+        return ResponseEntity.ok(commentDto);
+    }
+}

--- a/src/main/java/com/inconcert/domain/comment/controller/CommentController.java
+++ b/src/main/java/com/inconcert/domain/comment/controller/CommentController.java
@@ -7,11 +7,13 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import java.util.List;
 
 @Controller
 @RequiredArgsConstructor
+@RequestMapping("/comments")
 public class CommentController {
     private final CommentService commentService;
 

--- a/src/main/java/com/inconcert/domain/comment/dto/CommentCreateForm.java
+++ b/src/main/java/com/inconcert/domain/comment/dto/CommentCreateForm.java
@@ -9,8 +9,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -21,8 +19,6 @@ public class CommentCreateForm {
     private User user;
     private Post post;
     private boolean isSecret;
-    private LocalDateTime createdAt = LocalDateTime.now().withNano(0);
-    private LocalDateTime updateAt = LocalDateTime.now().withNano(0);
 
     @NotEmpty(message = "내용은 필수항목입니다.")
     private String content;
@@ -33,8 +29,6 @@ public class CommentCreateForm {
                 .user(getUser())
                 .post(getPost())
                 .content(getContent())
-                .createdAt(LocalDateTime.now().withNano(0))
-                .updatedAt(LocalDateTime.now().withNano(0))
                 .isSecret(isSecret())
                 .build();
         return comment;

--- a/src/main/java/com/inconcert/domain/comment/dto/CommentCreateForm.java
+++ b/src/main/java/com/inconcert/domain/comment/dto/CommentCreateForm.java
@@ -1,0 +1,42 @@
+package com.inconcert.domain.comment.dto;
+
+import com.inconcert.domain.comment.entity.Comment;
+import com.inconcert.domain.post.entity.Post;
+import com.inconcert.domain.user.entity.User;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+// 댓글 생성 폼 DTO
+public class CommentCreateForm {
+    private Long id;
+    private User user;
+    private Post post;
+    private boolean isSecret;
+    private LocalDateTime createdAt = LocalDateTime.now().withNano(0);
+    private LocalDateTime updateAt = LocalDateTime.now().withNano(0);
+
+    @NotEmpty(message = "내용은 필수항목입니다.")
+    private String content;
+
+    public Comment toEntity() {
+        Comment comment = Comment.builder()
+                .id(getId())
+                .user(getUser())
+                .post(getPost())
+                .content(getContent())
+                .createdAt(LocalDateTime.now().withNano(0))
+                .updatedAt(LocalDateTime.now().withNano(0))
+                .isSecret(isSecret())
+                .build();
+        return comment;
+    }
+}

--- a/src/main/java/com/inconcert/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/inconcert/domain/comment/dto/CommentDto.java
@@ -1,0 +1,28 @@
+package com.inconcert.domain.comment.dto;
+
+import com.inconcert.domain.comment.entity.Comment;
+import com.inconcert.domain.post.entity.Post;
+import com.inconcert.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.Set;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CommentDto {
+    private Long id;
+    private User user;
+    private Post post;
+    private String content;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+    private boolean isSecret;
+    private Comment parent;
+    private Set<Comment> replies;
+}

--- a/src/main/java/com/inconcert/domain/comment/dto/CommentDto.java
+++ b/src/main/java/com/inconcert/domain/comment/dto/CommentDto.java
@@ -8,7 +8,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
 import java.util.Set;
 
 @Getter
@@ -20,8 +19,6 @@ public class CommentDto {
     private User user;
     private Post post;
     private String content;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
     private boolean isSecret;
     private Comment parent;
     private Set<Comment> replies;

--- a/src/main/java/com/inconcert/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/inconcert/domain/comment/dto/CommentResponseDto.java
@@ -1,0 +1,32 @@
+package com.inconcert.domain.comment.dto;
+
+import com.inconcert.domain.comment.entity.Comment;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+// 응답용 댓글 DTO
+public class CommentResponseDto {
+    private Long id;
+    private String nickname;
+    private Long postId;
+    private String content;
+    private LocalDateTime updatedAt = LocalDateTime.now().withNano(0);
+    private boolean isSecret;
+
+    public CommentResponseDto(Comment comment) {
+        this.id = comment.getId();
+        this.nickname = comment.getUser().getUsername();
+        this.postId = comment.getPost().getId();
+        this.content = comment.getContent();
+        this.updatedAt = comment.getUpdatedAt();
+        this.isSecret = comment.getIsSecret();
+    }
+}

--- a/src/main/java/com/inconcert/domain/comment/dto/CommentResponseDto.java
+++ b/src/main/java/com/inconcert/domain/comment/dto/CommentResponseDto.java
@@ -6,8 +6,6 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.LocalDateTime;
-
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
@@ -18,7 +16,6 @@ public class CommentResponseDto {
     private String nickname;
     private Long postId;
     private String content;
-    private LocalDateTime updatedAt = LocalDateTime.now().withNano(0);
     private boolean isSecret;
 
     public CommentResponseDto(Comment comment) {
@@ -26,7 +23,6 @@ public class CommentResponseDto {
         this.nickname = comment.getUser().getUsername();
         this.postId = comment.getPost().getId();
         this.content = comment.getContent();
-        this.updatedAt = comment.getUpdatedAt();
         this.isSecret = comment.getIsSecret();
     }
 }

--- a/src/main/java/com/inconcert/domain/comment/entity/Comment.java
+++ b/src/main/java/com/inconcert/domain/comment/entity/Comment.java
@@ -5,10 +5,6 @@ import com.inconcert.domain.post.entity.Post;
 import com.inconcert.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
-import org.springframework.data.annotation.CreatedDate;
-import org.springframework.data.annotation.LastModifiedDate;
-
-import java.time.LocalDateTime;
 import java.util.Set;
 
 @Entity
@@ -34,12 +30,6 @@ public class Comment {
     @Column(nullable = false)
     private String content;
 
-    @CreatedDate
-    private LocalDateTime createdAt;
-
-    @LastModifiedDate
-    private LocalDateTime updatedAt;
-
     @Column
     private Boolean isSecret = false;
 
@@ -54,7 +44,6 @@ public class Comment {
     public void update(String content, Boolean isSecret) {
         this.content = content;
         this.isSecret = isSecret;
-        updatedAt = LocalDateTime.now().withNano(0);
     }
 
     public void confirmPost(Post post) {
@@ -77,8 +66,6 @@ public class Comment {
                 .user(user)
                 .post(post)
                 .content(content)
-                .createdAt(createdAt)
-                .updatedAt(updatedAt)
                 .isSecret(isSecret)
                 .replies(replies)
                 .build();

--- a/src/main/java/com/inconcert/domain/comment/entity/Comment.java
+++ b/src/main/java/com/inconcert/domain/comment/entity/Comment.java
@@ -3,8 +3,11 @@ package com.inconcert.domain.comment.entity;
 import com.inconcert.domain.comment.dto.CommentDto;
 import com.inconcert.domain.post.entity.Post;
 import com.inconcert.domain.user.entity.User;
+import com.inconcert.global.entity.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.HashSet;
 import java.util.Set;
 
 @Entity
@@ -14,7 +17,7 @@ import java.util.Set;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class Comment {
+public class Comment extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -33,12 +36,12 @@ public class Comment {
     @Column
     private Boolean isSecret = false;
 
-    @ManyToOne
-    @JoinColumn(name = "parent_id", nullable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_id")
     private Comment parent;
 
     @OneToMany(mappedBy = "parent", cascade = CascadeType.ALL, orphanRemoval = true)
-    private Set<Comment> replies;
+    private Set<Comment> replies = new HashSet<>();
 
     // 댓글 수정
     public void update(String content, Boolean isSecret) {

--- a/src/main/java/com/inconcert/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/inconcert/domain/comment/repository/CommentRepository.java
@@ -2,9 +2,11 @@ package com.inconcert.domain.comment.repository;
 
 import com.inconcert.domain.comment.entity.Comment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+@Repository
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findByPostId(Long id);
 }

--- a/src/main/java/com/inconcert/domain/comment/repository/CommentRepository.java
+++ b/src/main/java/com/inconcert/domain/comment/repository/CommentRepository.java
@@ -1,0 +1,10 @@
+package com.inconcert.domain.comment.repository;
+
+import com.inconcert.domain.comment.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByPostId(Long id);
+}

--- a/src/main/java/com/inconcert/domain/comment/service/CommentService.java
+++ b/src/main/java/com/inconcert/domain/comment/service/CommentService.java
@@ -3,6 +3,7 @@ package com.inconcert.domain.comment.service;
 import com.inconcert.domain.comment.dto.CommentDto;
 import com.inconcert.domain.comment.entity.Comment;
 import com.inconcert.domain.comment.repository.CommentRepository;
+import com.inconcert.global.exception.CommentNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -28,13 +29,13 @@ public class CommentService {
 
     @Transactional
     public CommentDto findComment(Long id) {
-        Comment comment = commentRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("ID = " + id + " 의 해당 댓글이 존재하지 않습니다."));
+        Comment comment = commentRepository.findById(id).orElseThrow(() -> new CommentNotFoundException("ID = " + id + " 의 해당 댓글이 존재하지 않습니다."));
         return comment.toCommentDto();
     }
 
     @Transactional
     public void delete(Long id) {
-        Comment comment = commentRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("ID = " + id + " 의 해당 댓글이 존재하지 않습니다."));
+        Comment comment = commentRepository.findById(id).orElseThrow(() -> new CommentNotFoundException("ID = " + id + " 의 해당 댓글이 존재하지 않습니다."));
         commentRepository.delete(comment);
     }
 }

--- a/src/main/java/com/inconcert/domain/comment/service/CommentService.java
+++ b/src/main/java/com/inconcert/domain/comment/service/CommentService.java
@@ -1,0 +1,40 @@
+package com.inconcert.domain.comment.service;
+
+import com.inconcert.domain.comment.dto.CommentDto;
+import com.inconcert.domain.comment.entity.Comment;
+import com.inconcert.domain.comment.repository.CommentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CommentService {
+    private final CommentRepository commentRepository;
+
+    @Transactional(readOnly = true)
+    public List<CommentDto> findByPostId(Long Id) {
+        List<Comment> byPostId = commentRepository.findByPostId(Id);
+        List<CommentDto> dtoList = new ArrayList<>();
+
+        for (Comment comment : byPostId) {
+            dtoList.add(comment.toCommentDto());
+        }
+        return dtoList;
+    }
+
+    @Transactional
+    public CommentDto findComment(Long id) {
+        Comment comment = commentRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("ID = " + id + " 의 해당 댓글이 존재하지 않습니다."));
+        return comment.toCommentDto();
+    }
+
+    @Transactional
+    public void delete(Long id) {
+        Comment comment = commentRepository.findById(id).orElseThrow(() -> new IllegalArgumentException("ID = " + id + " 의 해당 댓글이 존재하지 않습니다."));
+        commentRepository.delete(comment);
+    }
+}

--- a/src/main/java/com/inconcert/domain/comment/service/CommentService.java
+++ b/src/main/java/com/inconcert/domain/comment/service/CommentService.java
@@ -1,5 +1,6 @@
 package com.inconcert.domain.comment.service;
 
+import com.inconcert.domain.comment.dto.CommentCreateForm;
 import com.inconcert.domain.comment.dto.CommentDto;
 import com.inconcert.domain.comment.entity.Comment;
 import com.inconcert.domain.comment.repository.CommentRepository;
@@ -31,6 +32,14 @@ public class CommentService {
     public CommentDto findComment(Long id) {
         Comment comment = commentRepository.findById(id).orElseThrow(() -> new CommentNotFoundException("ID = " + id + " 의 해당 댓글이 존재하지 않습니다."));
         return comment.toCommentDto();
+    }
+
+    @Transactional
+    public Long CommentUpdate(Long id, CommentCreateForm dto) {
+        Comment comment = commentRepository.findById(id).orElseThrow(() -> new CommentNotFoundException("ID = " + id + " 의 해당 댓글이 존재하지 않습니다."));
+        comment.update(dto.getContent(), dto.isSecret());
+        commentRepository.save(comment);
+        return comment.getId();
     }
 
     @Transactional

--- a/src/main/java/com/inconcert/global/exception/CommentNotFoundException.java
+++ b/src/main/java/com/inconcert/global/exception/CommentNotFoundException.java
@@ -1,0 +1,7 @@
+package com.inconcert.global.exception;
+
+public class CommentNotFoundException extends RuntimeException {
+    public CommentNotFoundException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/inconcert/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/inconcert/global/handler/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package com.inconcert.global.handler;
+
+import com.inconcert.global.exception.CommentNotFoundException;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class GlobalExceptionHandler {
+    @ExceptionHandler(CommentNotFoundException.class)
+    public ResponseEntity<String> handleCommentNotFoundException(CommentNotFoundException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## 요약 #8 
- Comment 컨트롤러, DTO, Service, Repo 추가 (불필요한 필드 삭제 / 예외처리 수정)

## 추가사항
- 컨트롤러 / 조회 기능 구현
- DTO / 용도에 따라 세분화하여 구현
- Service / 조회 및 삭제 구현
- Repository 기능 구현

## 수정사항
- 컨트롤러 path / url 카멜 표기법으로 수정
- Comment Entity 내 createAt, updateAt 삭제(BaseEntity에서 상속받기 때문)
- @ Repository 어노테이션 추가
- IllegalArgumentException -> GlobalExceptionHandler(CommentNotFoundException)로 변경

- [ O ] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ O ] 🧹 불필요한 코드는 제거했나요?
- [ O ] 💭 (선택) 이슈는 등록했나요?
- [ O ] 🏷️ 라벨은 등록했나요?
- [ O ] 💻 git rebase를 사용했나요?