### PR TITLE
[Fix]: home과 board 페이지에서 제목이 길면 잘리는 문제 해결

### DIFF
--- a/src/main/resources/static/css/board/board.css
+++ b/src/main/resources/static/css/board/board.css
@@ -296,6 +296,7 @@ header {
 }
 
 .post-left{
+    flex: 4;
     display: flex;
     align-items: center;
 }
@@ -308,6 +309,14 @@ header {
 
 .post-left a:hover{
     text-decoration: underline;
+}
+
+.post-title {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 200px;
+    display: block;
 }
 
 .comment-count{
@@ -338,5 +347,11 @@ header {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    flex: 3;
     gap: 10px;
+}
+
+.post-right > p{
+    text-align: center;
+    flex: 1;
 }

--- a/src/main/resources/static/css/home.css
+++ b/src/main/resources/static/css/home.css
@@ -292,6 +292,7 @@ header {
 }
 
 .post-left{
+    flex: 4;
     display: flex;
     align-items: center;
 }
@@ -300,6 +301,18 @@ header {
     text-decoration: none;
     color: black;
     padding: 0;
+}
+
+.post-left a:hover{
+    text-decoration: underline;
+}
+
+.post-title {
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 270px; /* 너비를 조정하세요 */
+    display: block; /* 블록 요소로 설정하여 너비 제한 적용 */
 }
 
 .comment-count{
@@ -330,5 +343,11 @@ header {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    flex: 3;
     gap: 10px;
+}
+
+.post-right > p{
+    text-align: center;
+    flex: 1;
 }

--- a/src/main/resources/templates/board/board-detail.html
+++ b/src/main/resources/templates/board/board-detail.html
@@ -72,7 +72,7 @@
                 </div>
                 <div class="post-meta">
                     <span class="author" th:text="${post.nickname}"></span>
-                    <span class="date" th:text="${#temporals.format(post.createdAt, 'yyyy-MM-dd HH:mm')}"></span>
+                    <span class="date" th:text="${#temporals.format(post.createdAt, 'yyyy-MM-dd')}"></span>
                     <span class="views" th:text="${post.viewCount}"></span>
                     <span class="likes" th:text="${post.likeCount}"></span>
                 </div>

--- a/src/main/resources/templates/board/board.html
+++ b/src/main/resources/templates/board/board.html
@@ -41,7 +41,7 @@
             <div class="post-list" th:each="post : ${Musicalposts}">
                 <div class="post-left">
                     <a th:href="@{'/' + ${categoryTitle} + '/musical/' + ${post.id}}">
-                        <p th:text="'[musical] '+ ${post.title}">Post Title</p>
+                        <p class="post-title" th:text="'[musical] '+ ${post.title}">Post Title</p>
                     </a>
                     <p class="comment-count">[<span th:text="${post.commentCount}"> </span>]</p>
                     <div th:if="${post.isNew}">
@@ -67,7 +67,7 @@
             <div class="post-list" th:each="post : ${Concertposts}">
                 <div class="post-left">
                     <a th:href="@{'/' + ${categoryTitle} + '/concert/' + ${post.id}}">
-                        <p th:text="'[concert] '+ ${post.title}">Post Title</p>
+                        <p class="post-title" th:text="'[concert] '+ ${post.title}">Post Title</p>
                     </a>
                     <p class="comment-count">[<span th:text="${post.commentCount}"> </span>]</p>
                     <div th:if="${post.isNew}">
@@ -95,7 +95,7 @@
             <div class="post-list" th:each="post : ${Theaterposts}">
                 <div class="post-left">
                     <a th:href="@{'/' + ${categoryTitle} + '/theater/' + ${post.id}}">
-                        <p th:text="'[theater] '+ ${post.title}">Post Title</p>
+                        <p class="post-title" th:text="'[theater] '+ ${post.title}">Post Title</p>
                     </a>
                     <p class="comment-count">[<span th:text="${post.commentCount}"> </span>]</p>
                     <div th:if="${post.isNew}">
@@ -120,7 +120,7 @@
             <div class="post-list" th:each="post : ${Etcposts}">
                 <div class="post-left">
                     <a th:href="@{'/' + ${categoryTitle} + '/etc/' + ${post.id}}">
-                        <p th:text="'[etc] '+ ${post.title}">Post Title</p>
+                        <p class="post-title" th:text="'[etc] '+ ${post.title}">Post Title</p>
                     </a>
                     <p class="comment-count">[<span th:text="${post.commentCount}"> </span>]</p>
                     <div th:if="${post.isNew}">

--- a/src/main/resources/templates/home.html
+++ b/src/main/resources/templates/home.html
@@ -36,7 +36,7 @@
             <div class="post-list" th:each="post : ${infoPosts}">
                 <div class="post-left">
                     <a th:href="@{'/info/' + ${post.postCategory.title} + '/' + ${post.id}}">
-                        <p th:text="'[' + ${post.postCategory.title} + ']  ' + ${post.title}">Post Title</p>
+                        <p class="post-title" th:text="'[' + ${post.postCategory.title} + ']  ' + ${post.title}">Post Title</p>
                     </a>
                     <p class="comment-count">[<span th:text="${post.commentCount}"> </span>]</p>
                     <div th:if="${post.isNew}">
@@ -45,7 +45,7 @@
                 </div>
 
                 <div class="post-right">
-                    <p><span th:text="${post.username}"></span></p>
+                    <p><span th:text="${post.nickname}"></span></p>
                     <p th:text="${#temporals.format(post.createdAt, 'yyyy-MM-dd')}"> </p>
                     <p><span th:text="${post.viewCount}"></span></p>
                 </div>
@@ -62,7 +62,7 @@
             <div class="post-list" th:each="post : ${reviewPosts}">
                 <div class="post-left">
                     <a th:href="@{'/review/' + ${post.postCategory.title} + '/' + ${post.id}}">
-                        <p th:text="'[' + ${post.postCategory.title} + ']  ' + ${post.title}">Post Title</p>
+                        <p class="post-title" th:text="'[' + ${post.postCategory.title} + ']  ' + ${post.title}">Post Title</p>
                     </a>
                     <p class="comment-count">[<span th:text="${post.commentCount}"> </span>]</p>
                     <div th:if="${post.isNew}">
@@ -71,7 +71,7 @@
                 </div>
 
                 <div class="post-right">
-                    <p><span th:text="${post.username}"></span></p>
+                    <p><span th:text="${post.nickname}"></span></p>
                     <p th:text="${#temporals.format(post.createdAt, 'yyyy-MM-dd')}"> </p>
                     <p><span th:text="${post.viewCount}"></span></p>
                 </div>
@@ -90,7 +90,7 @@
             <div class="post-list" th:each="post : ${matchPosts}">
                 <div class="post-left">
                     <a th:href="@{'/match/' + ${post.postCategory.title} + '/' + ${post.id}}">
-                        <p th:text="'[' + ${post.postCategory.title} + ']  ' + ${post.title}">Post Title</p>
+                        <p class="post-title" th:text="'[' + ${post.postCategory.title} + ']  ' + ${post.title}">Post Title</p>
                     </a>
                     <p class="comment-count">[<span th:text="${post.commentCount}"> </span>]</p>
                     <div th:if="${post.isNew}">
@@ -99,7 +99,7 @@
                 </div>
 
                 <div class="post-right">
-                    <p><span th:text="${post.username}"></span></p>
+                    <p><span th:text="${post.nickname}"></span></p>
                     <p th:text="${#temporals.format(post.createdAt, 'yyyy-MM-dd')}"> </p>
                     <p><span th:text="${post.viewCount}"></span></p>
                 </div>
@@ -115,7 +115,7 @@
             <div class="post-list" th:each="post : ${transferPosts}">
                 <div class="post-left">
                     <a th:href="@{'/transfer/' + ${post.postCategory.title} + '/' + ${post.id}}">
-                        <p th:text="'[' + ${post.postCategory.title} + ']  ' + ${post.title}">Post Title</p>
+                        <p class="post-title" th:text="'[' + ${post.postCategory.title} + ']  ' + ${post.title}">Post Title</p>
                     </a>
                     <p class="comment-count">[<span th:text="${post.commentCount}"> </span>]</p>
                     <div th:if="${post.isNew}">
@@ -124,7 +124,7 @@
                 </div>
 
                 <div class="post-right">
-                    <p><span th:text="${post.username}"></span></p>
+                    <p><span th:text="${post.nickname}"></span></p>
                     <p th:text="${#temporals.format(post.createdAt, 'yyyy-MM-dd')}"> </p>
                     <p><span th:text="${post.viewCount}"></span></p>
                 </div>


### PR DESCRIPTION
## 요약 #21
- home과 board 페이지에서 제목이 길면 잘리는 문제 해결

## 추가사항
- text-overflow: ellipsis; 옵션 추가

## 수정사항
- board 날짜 시간 표시 제거

<br>

- [ ✅ ] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ✅ ] 🧹 불필요한 코드는 제거했나요?
- [ ✅ ] 💭 (선택) 이슈는 등록했나요?
- [ ✅ ] 🏷️ 라벨은 등록했나요?
- [ ✅ ] 💻 git rebase를 사용했나요?