### PR TITLE
[Feat]: 게시물 카테고리 페이지 검색 구현

### DIFF
--- a/src/main/java/com/inconcert/domain/like/service/LikeService.java
+++ b/src/main/java/com/inconcert/domain/like/service/LikeService.java
@@ -75,13 +75,11 @@ public class LikeService {
         return post;
     }
 
-    // 로그아웃 상태: null 리턴
-    // 로그인 상태: User 리턴
     private User getUser() {
-        User user;
-        Optional<User> loginUser = userService.getAuthenticatedUser();
-        if (loginUser == null || !loginUser.isPresent()) return null;
-        else user = loginUser.orElseThrow(() -> new UserNotFoundException("유저를 찾을 수 없습니다."));
+        Optional<User> optionalUser = userService.getAuthenticatedUser();
+        if (optionalUser.isEmpty()) return null;
+
+        User user = optionalUser.orElseThrow(() -> new UserNotFoundException("유저를 찾을 수 없습니다."));
         return user;
     }
 }

--- a/src/main/java/com/inconcert/domain/post/controller/InfoController.java
+++ b/src/main/java/com/inconcert/domain/post/controller/InfoController.java
@@ -45,12 +45,13 @@ public class InfoController {
         return "board/post-detail";
     }
 
-    @GetMapping("/search")
-    public String search(@RequestParam(name = "keyword") String keyword,
+    @GetMapping("/{postCategoryTitle}/search")
+    public String search(@PathVariable("postCategoryTitle") String postCategoryTitle,
+                         @RequestParam(name = "keyword") String keyword,
                          @RequestParam(name = "period", required = false, defaultValue = "all") String period,
                          @RequestParam(name = "type", required = false, defaultValue = "title+content") String type,
                          Model model) {
-        List<PostDto> searchResults = infoService.findByKeywordAndFilters(keyword, period, type);
+        List<PostDto> searchResults = infoService.findByKeywordAndFilters(postCategoryTitle, keyword, period, type);
         model.addAttribute("posts", searchResults);
         model.addAttribute("categoryTitle", "info");
         return "board/board-detail";

--- a/src/main/java/com/inconcert/domain/post/controller/MatchController.java
+++ b/src/main/java/com/inconcert/domain/post/controller/MatchController.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Controller
 @RequestMapping("/match")
 @RequiredArgsConstructor
@@ -41,6 +43,18 @@ public class MatchController {
         model.addAttribute("categoryTitle", "match");
         model.addAttribute("postCategoryTitle", postCategoryTitle);
         return "board/post-detail";
+    }
+
+    @GetMapping("/{postCategoryTitle}/search")
+    public String search(@PathVariable("postCategoryTitle") String postCategoryTitle,
+                         @RequestParam(name = "keyword") String keyword,
+                         @RequestParam(name = "period", required = false, defaultValue = "all") String period,
+                         @RequestParam(name = "type", required = false, defaultValue = "title+content") String type,
+                         Model model) {
+        List<PostDto> searchResults = matchService.findByKeywordAndFilters(postCategoryTitle, keyword, period, type);
+        model.addAttribute("posts", searchResults);
+        model.addAttribute("categoryTitle", "match");
+        return "board/board-detail";
     }
 
     @PostMapping("/write")

--- a/src/main/java/com/inconcert/domain/post/controller/ReviewController.java
+++ b/src/main/java/com/inconcert/domain/post/controller/ReviewController.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Controller
 @RequestMapping("/review")
 @RequiredArgsConstructor
@@ -32,6 +34,17 @@ public class ReviewController {
         model.addAttribute("categoryTitle", "review");
         model.addAttribute("postCategoryTitle", postCategoryTitle);
         return "board/post-detail";
+    }
+
+    @GetMapping("/search")
+    public String search(@RequestParam(name = "keyword") String keyword,
+                         @RequestParam(name = "period", required = false, defaultValue = "all") String period,
+                         @RequestParam(name = "type", required = false, defaultValue = "title+content") String type,
+                         Model model) {
+        List<PostDto> searchResults = reviewService.findByKeywordAndFilters(keyword, period, type);
+        model.addAttribute("posts", searchResults);
+        model.addAttribute("categoryTitle", "review");
+        return "board/board-detail";
     }
 
     @PostMapping("/write")

--- a/src/main/java/com/inconcert/domain/post/controller/TransferController.java
+++ b/src/main/java/com/inconcert/domain/post/controller/TransferController.java
@@ -8,6 +8,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 @Controller
 @RequestMapping("/transfer")
 @RequiredArgsConstructor
@@ -41,6 +43,18 @@ public class TransferController {
         model.addAttribute("categoryTitle", "transfer");
         model.addAttribute("postCategoryTitle", postCategoryTitle);
         return "board/post-detail";
+    }
+
+    @GetMapping("/{postCategoryTitle}/search")
+    public String search(@PathVariable("postCategoryTitle") String postCategoryTitle,
+                         @RequestParam(name = "keyword") String keyword,
+                         @RequestParam(name = "period", required = false, defaultValue = "all") String period,
+                         @RequestParam(name = "type", required = false, defaultValue = "title+content") String type,
+                         Model model) {
+        List<PostDto> searchResults = transferService.findByKeywordAndFilters(postCategoryTitle, keyword, period, type);
+        model.addAttribute("posts", searchResults);
+        model.addAttribute("categoryTitle", "transfer");
+        return "board/board-detail";
     }
 
     @PostMapping("/write")

--- a/src/main/java/com/inconcert/domain/post/repository/InfoRepository.java
+++ b/src/main/java/com/inconcert/domain/post/repository/InfoRepository.java
@@ -27,13 +27,14 @@ public interface InfoRepository extends JpaRepository<Post, Long> {
             "JOIN FETCH p.postCategory pc " +
             "JOIN FETCH pc.category c " +
             "JOIN FETCH p.user u " +
-            "WHERE c.title = 'info' AND " +
-            "((p.title LIKE %:keyword% OR p.content LIKE %:keyword%) AND " +
-            "p.createdAt BETWEEN :startDate AND :endDate AND " +
-            "(:type = 'title+content' OR (:type = 'title' AND p.title LIKE %:keyword%) " +
-            "OR (:type = 'content' AND p.content LIKE %:keyword%) " +
-            "OR (:type = 'author' AND u.nickname LIKE %:keyword%)))")
-    List<Post> findByKeywordAndFilters(@Param("keyword") String keyword,
+            "WHERE c.title = 'info' AND pc.title = :postCategoryTitle " +
+            "AND ((:type = 'title+content' AND (p.title LIKE %:keyword% OR p.content LIKE %:keyword%)) " +
+            "OR   (:type = 'title' AND p.title LIKE %:keyword%) " +
+            "OR   (:type = 'content' AND p.content LIKE %:keyword%) " +
+            "OR   (:type = 'author' AND u.nickname LIKE %:keyword%)) " +
+            "AND p.createdAt BETWEEN :startDate AND :endDate")
+    List<Post> findByKeywordAndFilters(@Param("postCategoryTitle") String postCategoryTitle,
+                                       @Param("keyword") String keyword,
                                        @Param("startDate") LocalDateTime startDate,
                                        @Param("endDate") LocalDateTime endDate,
                                        @Param("type") String type);

--- a/src/main/java/com/inconcert/domain/post/repository/MatchRepository.java
+++ b/src/main/java/com/inconcert/domain/post/repository/MatchRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -21,4 +22,20 @@ public interface MatchRepository extends JpaRepository<Post, Long> {
             "JOIN FETCH pc.category c " +
             "WHERE c.title = 'match'")
     List<Post> findPostsByCategoryTitleMatch();
+
+    @Query("SELECT p FROM Post p " +
+            "JOIN FETCH p.postCategory pc " +
+            "JOIN FETCH pc.category c " +
+            "JOIN FETCH p.user u " +
+            "WHERE c.title = 'match' AND pc.title = :postCategoryTitle " +
+            "AND ((:type = 'title+content' AND (p.title LIKE %:keyword% OR p.content LIKE %:keyword%)) " +
+            "OR   (:type = 'title' AND p.title LIKE %:keyword%) " +
+            "OR   (:type = 'content' AND p.content LIKE %:keyword%) " +
+            "OR   (:type = 'author' AND u.nickname LIKE %:keyword%)) " +
+            "AND p.createdAt BETWEEN :startDate AND :endDate")
+    List<Post> findByKeywordAndFilters(@Param("postCategoryTitle") String postCategoryTitle,
+                                       @Param("keyword") String keyword,
+                                       @Param("startDate") LocalDateTime startDate,
+                                       @Param("endDate") LocalDateTime endDate,
+                                       @Param("type") String type);
 }

--- a/src/main/java/com/inconcert/domain/post/repository/ReviewRepository.java
+++ b/src/main/java/com/inconcert/domain/post/repository/ReviewRepository.java
@@ -3,8 +3,10 @@ package com.inconcert.domain.post.repository;
 import com.inconcert.domain.post.entity.Post;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -14,4 +16,19 @@ public interface ReviewRepository extends JpaRepository<Post, Long> {
             "JOIN FETCH pc.category c " +
             "WHERE c.title = 'review'")
     List<Post> findPostsByCategoryTitleReview();
+
+    @Query("SELECT p FROM Post p " +
+            "JOIN FETCH p.postCategory pc " +
+            "JOIN FETCH pc.category c " +
+            "JOIN FETCH p.user u " +
+            "WHERE c.title = 'review'"+
+            "AND ((:type = 'title+content' AND (p.title LIKE %:keyword% OR p.content LIKE %:keyword%)) " +
+            "OR   (:type = 'title' AND p.title LIKE %:keyword%) " +
+            "OR   (:type = 'content' AND p.content LIKE %:keyword%) " +
+            "OR   (:type = 'author' AND u.nickname LIKE %:keyword%)) " +
+            "AND p.createdAt BETWEEN :startDate AND :endDate")
+    List<Post> findByKeywordAndFilters(@Param("keyword") String keyword,
+                                       @Param("startDate") LocalDateTime startDate,
+                                       @Param("endDate") LocalDateTime endDate,
+                                       @Param("type") String type);
 }

--- a/src/main/java/com/inconcert/domain/post/repository/TransferRepository.java
+++ b/src/main/java/com/inconcert/domain/post/repository/TransferRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -21,4 +22,20 @@ public interface TransferRepository extends JpaRepository<Post, Long> {
             "JOIN FETCH pc.category c " +
             "WHERE c.title = 'transfer'")
     List<Post> findPostsByCategoryTitleTransfer();
+
+    @Query("SELECT p FROM Post p " +
+            "JOIN FETCH p.postCategory pc " +
+            "JOIN FETCH pc.category c " +
+            "JOIN FETCH p.user u " +
+            "WHERE c.title = 'transfer' AND pc.title = :postCategoryTitle " +
+            "AND ((:type = 'title+content' AND (p.title LIKE %:keyword% OR p.content LIKE %:keyword%)) " +
+            "OR   (:type = 'title' AND p.title LIKE %:keyword%) " +
+            "OR   (:type = 'content' AND p.content LIKE %:keyword%) " +
+            "OR   (:type = 'author' AND u.nickname LIKE %:keyword%)) " +
+            "AND p.createdAt BETWEEN :startDate AND :endDate")
+    List<Post> findByKeywordAndFilters(@Param("postCategoryTitle") String postCategoryTitle,
+                                       @Param("keyword") String keyword,
+                                       @Param("startDate") LocalDateTime startDate,
+                                       @Param("endDate") LocalDateTime endDate,
+                                       @Param("type") String type);
 }

--- a/src/main/java/com/inconcert/domain/post/service/InfoService.java
+++ b/src/main/java/com/inconcert/domain/post/service/InfoService.java
@@ -68,17 +68,13 @@ public class InfoService {
     }
 
     @Transactional(readOnly = true)
-    public List<PostDto> findByKeywordAndFilters(String keyword, String period, String type) {
+    public List<PostDto> findByKeywordAndFilters(String postCategoryTitle, String keyword, String period, String type) {
+        LocalDateTime startDate = DateUtil.getStartDate(period);
+        LocalDateTime endDate = DateUtil.getCurrentDate();
 
-        LocalDateTime startDate = DateUtil.getCurrentDate();
-        LocalDateTime endDate = DateUtil.getEndDate(period);
         // 검색 로직 구현 (기간 필터링, 타입 필터링 등)
-        List<Post> posts = infoRepository.findByKeywordAndFilters(keyword, startDate, endDate, type);
+        List<Post> posts = infoRepository.findByKeywordAndFilters(postCategoryTitle, keyword, startDate, endDate, type);
         List<PostDto> postDtos = getPostDtos(posts);
-
-        for (PostDto postDto : postDtos) {
-            System.out.println(postDto.getTitle());
-        }
 
         return postDtos;
     }

--- a/src/main/java/com/inconcert/domain/post/service/MatchService.java
+++ b/src/main/java/com/inconcert/domain/post/service/MatchService.java
@@ -7,6 +7,7 @@ import com.inconcert.domain.category.repository.PostCategoryRepository;
 import com.inconcert.domain.post.dto.PostDto;
 import com.inconcert.domain.post.entity.Post;
 import com.inconcert.domain.post.repository.MatchRepository;
+import com.inconcert.domain.post.util.DateUtil;
 import com.inconcert.domain.user.service.UserService;
 import com.inconcert.global.exception.CategoryNotFoundException;
 import com.inconcert.global.exception.PostCategoryNotFoundException;
@@ -37,21 +38,7 @@ public class MatchService {
             default -> throw new PostCategoryNotFoundException("찾으려는 PostCategory가 존재하지 않습니다.");
         };
 
-        List<PostDto> postDtos = new ArrayList<>();
-        for (Post post : posts) {
-            PostDto postDto = PostDto.builder()
-                    .id(post.getId())
-                    .title(post.getTitle())
-                    .postCategory(post.getPostCategory())
-                    .nickname(post.getUser().getNickname())
-                    .viewCount(post.getViewCount() + 1)
-                    .commentCount(post.getComments().size())
-                    .likeCount(post.getLikes().size())
-                    .isNew(Duration.between(post.getCreatedAt(), LocalDateTime.now()).toDays() < 1)
-                    .createdAt(post.getCreatedAt())
-                    .build();
-            postDtos.add(postDto);
-        }
+        List<PostDto> postDtos = getPostDtos(posts);
         return postDtos;
     }
 
@@ -78,6 +65,18 @@ public class MatchService {
                 .isNew(Duration.between(post.getCreatedAt(), LocalDateTime.now()).toDays() < 1)
                 .createdAt(post.getCreatedAt())
                 .build();
+    }
+
+    @Transactional(readOnly = true)
+    public List<PostDto> findByKeywordAndFilters(String postCategoryTitle, String keyword, String period, String type) {
+        LocalDateTime startDate = DateUtil.getStartDate(period);
+        LocalDateTime endDate = DateUtil.getCurrentDate();
+
+        // 검색 로직 구현 (기간 필터링, 타입 필터링 등)
+        List<Post> posts = matchRepository.findByKeywordAndFilters(postCategoryTitle, keyword, startDate, endDate, type);
+        List<PostDto> postDtos = getPostDtos(posts);
+
+        return postDtos;
     }
 
     @Transactional
@@ -110,5 +109,24 @@ public class MatchService {
         Post post = PostDto.toEntity(postDto, updatedPostCategory);
 
         matchRepository.save(post);
+    }
+
+    private static List<PostDto> getPostDtos(List<Post> posts) {
+        List<PostDto> postDtos = new ArrayList<>();
+        for (Post post : posts) {
+            PostDto postDto = PostDto.builder()
+                    .id(post.getId())
+                    .title(post.getTitle())
+                    .postCategory(post.getPostCategory())
+                    .nickname(post.getUser().getNickname())
+                    .viewCount(post.getViewCount() + 1)
+                    .commentCount(post.getComments().size())
+                    .likeCount(post.getLikes().size())
+                    .isNew(Duration.between(post.getCreatedAt(), LocalDateTime.now()).toDays() < 1)
+                    .createdAt(post.getCreatedAt())
+                    .build();
+            postDtos.add(postDto);
+        }
+        return postDtos;
     }
 }

--- a/src/main/java/com/inconcert/domain/post/util/DateUtil.java
+++ b/src/main/java/com/inconcert/domain/post/util/DateUtil.java
@@ -3,21 +3,16 @@ package com.inconcert.domain.post.util;
 import java.time.LocalDateTime;
 
 public class DateUtil {
-    public static LocalDateTime getEndDate(String period) {
-        switch (period) {
-            case "1day":
-                return LocalDateTime.now().plusDays(1);
-            case "1week":
-                return LocalDateTime.now().plusWeeks(1);
-            case "1month":
-                return LocalDateTime.now().plusMonths(1);
-            case "6months":
-                return LocalDateTime.now().plusMonths(6);
-            case "1year":
-                return LocalDateTime.now().plusYears(1);
-            default:
-                return LocalDateTime.MIN;
-        }
+    public static LocalDateTime getStartDate(String period) {
+        return switch (period) {
+            case "all" -> LocalDateTime.now().minusYears(100);
+            case "1day" -> LocalDateTime.now().minusDays(1);
+            case "1week" -> LocalDateTime.now().minusWeeks(1);
+            case "1month" -> LocalDateTime.now().minusMonths(1);
+            case "6months" -> LocalDateTime.now().minusMonths(6);
+            case "1year" -> LocalDateTime.now().minusYears(1);
+            default -> LocalDateTime.MIN;
+        };
     }
 
     public static LocalDateTime getCurrentDate() {

--- a/src/main/java/com/inconcert/domain/user/service/UserService.java
+++ b/src/main/java/com/inconcert/domain/user/service/UserService.java
@@ -176,7 +176,7 @@ public class UserService {
         try {
             Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
             UserDetails principal = (UserDetails) authentication.getPrincipal();
-            String username = principal.getUsername();
+            String username = principal != null ? principal.getUsername() : null;
 
             return userRepository.findByUsername(username);
         } catch (Exception e) {

--- a/src/main/java/com/inconcert/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/inconcert/global/handler/GlobalExceptionHandler.java
@@ -43,8 +43,4 @@ public class GlobalExceptionHandler {
     public ResponseEntity<String> handleLikeNotFoundException(LikeNotFoundException ex) {
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.NOT_FOUND);
     }
-
-
-
-
 }

--- a/src/main/resources/static/css/board/board-detail.css
+++ b/src/main/resources/static/css/board/board-detail.css
@@ -295,6 +295,20 @@ header {
     border: 1px solid #ccc;
 }
 
+.filters > button{
+    background-color: #00A885;
+    color: white;
+    text-decoration: none;
+    border: 1px #6f6f6f solid;
+    border-radius: 15px;
+    padding: 5px 10px;
+    font-size: 18px;
+}
+
+.filters > button:hover{
+    cursor: pointer;
+}
+
 .post-header {
     display: flex;
     justify-content: space-between;

--- a/src/main/resources/templates/board/board-detail.html
+++ b/src/main/resources/templates/board/board-detail.html
@@ -51,7 +51,28 @@
 
     <div class="review-block" th:if="${categoryTitle} == 'review'"></div>
 
-    <div class="filters-container">
+    <div class="filters-container" th:if="${categoryTitle} != 'review'">
+        <form class="filters" onsubmit="return validateDetailSearch()" th:action="@{'/' + ${categoryTitle} + '/' + ${postCategoryTitle} + '/search'}" method="get">
+            <select id="search-period" name="period">
+                <option value="all">전체 기간</option>
+                <option value="1day">1일</option>
+                <option value="1week">1주</option>
+                <option value="1month">1개월</option>
+                <option value="6months">6개월</option>
+                <option value="1year">1년</option>
+            </select>
+            <select id="search-type" name="type">
+                <option value="title+content">제목 + 내용</option>
+                <option value="title">제목만</option>
+                <option value="content">내용만</option>
+                <option value="author">글 작성자</option>
+            </select>
+            <input id="search-detail-input" type="text" name="keyword" placeholder="검색어를 입력해주세요">
+            <button type="submit">검색</button>
+        </form>
+    </div>
+
+    <div class="filters-container" th:if="${categoryTitle} == 'review'">
         <form class="filters" onsubmit="return validateDetailSearch()" th:action="@{'/' + ${categoryTitle} + '/search'}" method="get">
             <select id="search-period" name="period">
                 <option value="all">전체 기간</option>

--- a/src/main/resources/templates/board/post-detail.html
+++ b/src/main/resources/templates/board/post-detail.html
@@ -66,7 +66,6 @@
             <i class="like-icon far fa-heart" id="like-icon"
                th:data-post-id="${post.id}"
                th:data-category-title="${categoryTitle}"
-               th:data-user="${user}"
                onclick="toggleLike(this)"></i>
             <span id="like-count" th:text="${post.likeCount}"></span>
             <span th:text="'댓글 '+ ${post.commentCount}"></span>

--- a/src/main/resources/templates/board/writeform.html
+++ b/src/main/resources/templates/board/writeform.html
@@ -26,7 +26,7 @@
             <div class="dropdowns">
                 <select id="categoryTitle" name="categoryTitle" required>
                     <option disabled selected value="default">게시판 선택</option>
-                    <option value="info">공연 정보</option>
+                    <option value="info">공연 소식</option>
                     <option value="review">공연 후기</option>
                     <option value="match">동행</option>
                     <option value="transfer">양도</option>


### PR DESCRIPTION
## 요약 #37 
- 게시물 카테고리 페이지 검색 구현

## 추가사항
- 검색 옵션 설정 가능 - 검색 옵션 중 날짜 구분은 DateUtil 클래스 생성해 분리
- 공연 후기 게시판 검색은 요청 URL 다름
- 2글자 이상 검색어 입력하지 않는 경우 검색 불가

## 수정사항
- 중복되는 코드 메소드 추출

<br>

- [ ✅ ] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ✅ ] 🧹 불필요한 코드는 제거했나요?
- [ ✅ ] 💭 (선택) 이슈는 등록했나요?
- [ ✅ ] 🏷️ 라벨은 등록했나요?
- [ ✅ ] 💻 git rebase를 사용했나요?