### PR TITLE
[Feat]: 글 작성 및 수정 시 동행 글 선택 로직, 종료날짜 불러오기, 관리자만 공연 소식 글 작성 가능

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,6 +40,7 @@ dependencies {
 	implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
 	runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
+
 	//gson
 	implementation 'com.google.code.gson:gson'
 

--- a/src/main/java/com/inconcert/domain/post/controller/InfoController.java
+++ b/src/main/java/com/inconcert/domain/post/controller/InfoController.java
@@ -5,6 +5,7 @@ import com.inconcert.domain.post.dto.PostDto;
 import com.inconcert.domain.post.entity.Post;
 import com.inconcert.domain.post.service.EditService;
 import com.inconcert.domain.post.service.InfoService;
+import com.inconcert.domain.post.service.WriteService;
 import com.inconcert.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -21,6 +22,7 @@ public class InfoController {
     private final InfoService infoService;
     private final UserService userService;
     private final EditService editService;
+    private final WriteService writeService;
 
     @GetMapping
     public String info(Model model) {
@@ -99,7 +101,7 @@ public class InfoController {
 
     @PostMapping("/write")
     public String write(@ModelAttribute PostDto postDto){
-        Post post = infoService.save(postDto);
+        Post post = writeService.save(postDto);
         return "redirect:/info/" + post.getPostCategory().getTitle() + '/' + post.getId();
     }
 }

--- a/src/main/java/com/inconcert/domain/post/controller/MatchController.java
+++ b/src/main/java/com/inconcert/domain/post/controller/MatchController.java
@@ -5,6 +5,7 @@ import com.inconcert.domain.post.dto.PostDto;
 import com.inconcert.domain.post.entity.Post;
 import com.inconcert.domain.post.service.EditService;
 import com.inconcert.domain.post.service.MatchService;
+import com.inconcert.domain.post.service.WriteService;
 import com.inconcert.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -21,6 +22,7 @@ public class MatchController {
     private final MatchService matchService;
     private final UserService userService;
     private final EditService editService;
+    private final WriteService writeService;
 
     @GetMapping
     public String match(Model model) {
@@ -98,7 +100,7 @@ public class MatchController {
 
     @PostMapping("/write")
     public String write(@ModelAttribute PostDto postDto) {
-        Post post = matchService.save(postDto);
+        Post post = writeService.save(postDto);
         return "redirect:/match/" + post.getPostCategory().getTitle() + '/' + post.getId();
     }
 }

--- a/src/main/java/com/inconcert/domain/post/controller/ReviewController.java
+++ b/src/main/java/com/inconcert/domain/post/controller/ReviewController.java
@@ -5,6 +5,7 @@ import com.inconcert.domain.post.dto.PostDto;
 import com.inconcert.domain.post.entity.Post;
 import com.inconcert.domain.post.service.EditService;
 import com.inconcert.domain.post.service.ReviewService;
+import com.inconcert.domain.post.service.WriteService;
 import com.inconcert.domain.user.service.UserService;
 import com.inconcert.global.service.HomeService;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class ReviewController {
     private final HomeService homeService;
     private final UserService userService;
     private final EditService editService;
+    private final WriteService writeService;
 
     @GetMapping
     public String review(Model model) {
@@ -89,7 +91,7 @@ public class ReviewController {
 
     @PostMapping("/write")
     public String write(@ModelAttribute PostDto postDto) {
-        Post post = reviewService.save(postDto);
+        Post post = writeService.save(postDto);
         return "redirect:/review/" + post.getPostCategory().getTitle() + '/' + post.getId();
     }
 }

--- a/src/main/java/com/inconcert/domain/post/controller/TransferController.java
+++ b/src/main/java/com/inconcert/domain/post/controller/TransferController.java
@@ -5,6 +5,7 @@ import com.inconcert.domain.post.dto.PostDto;
 import com.inconcert.domain.post.entity.Post;
 import com.inconcert.domain.post.service.EditService;
 import com.inconcert.domain.post.service.TransferService;
+import com.inconcert.domain.post.service.WriteService;
 import com.inconcert.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
@@ -21,6 +22,7 @@ public class TransferController {
     private final TransferService transferService;
     private final UserService userService;
     private final EditService editService;
+    private final WriteService writeService;
 
     @GetMapping
     public String transfer(Model model) {
@@ -99,7 +101,7 @@ public class TransferController {
 
     @PostMapping("/write")
     public String write(@ModelAttribute PostDto postDto) {
-        Post post = transferService.save(postDto);
+        Post post = writeService.save(postDto);
         return "redirect:/transfer/" + post.getPostCategory().getTitle() + '/' + post.getId();
     }
 }

--- a/src/main/java/com/inconcert/domain/post/entity/Post.java
+++ b/src/main/java/com/inconcert/domain/post/entity/Post.java
@@ -31,10 +31,10 @@ public class Post extends BaseEntity {
     @Column(nullable = false, columnDefinition = "longtext")
     private String content;
 
-    @Column(name = "end_date", nullable = false)
+    @Column(name = "end_date")
     private LocalDate endDate;
 
-    @Column(name = "match_count", nullable = false)
+    @Column(name = "match_count")
     private int matchCount;
 
     @Column(name = "thumbnail_url")

--- a/src/main/java/com/inconcert/domain/post/service/EditService.java
+++ b/src/main/java/com/inconcert/domain/post/service/EditService.java
@@ -52,6 +52,12 @@ public class EditService {
 
         postDto.setThumbnailUrl(extractURL(postDto.getContent()));
 
+        // 동행을 제외한 카테고리들은 모집인원, 마감 날짜 제거
+        if(!category.equals("match")){
+            postDto.setMatchCount(0);
+            postDto.setEndDate(null);
+        }
+
         // 새로운 레포지토리에 저장
         Post updatedPost = Post.builder()
                 .id(currentPost.getId())

--- a/src/main/java/com/inconcert/domain/post/service/ReviewService.java
+++ b/src/main/java/com/inconcert/domain/post/service/ReviewService.java
@@ -1,18 +1,11 @@
 package com.inconcert.domain.post.service;
 
-import com.inconcert.domain.category.entity.Category;
-import com.inconcert.domain.category.entity.PostCategory;
-import com.inconcert.domain.category.repository.CategoryRepository;
-import com.inconcert.domain.category.repository.PostCategoryRepository;
-import com.inconcert.domain.notification.service.NotificationService;
 import com.inconcert.domain.post.dto.PostDto;
 import com.inconcert.domain.post.entity.Post;
 import com.inconcert.domain.post.repository.ReviewRepository;
 import com.inconcert.domain.post.util.DateUtil;
-import com.inconcert.domain.user.service.UserService;
 import com.inconcert.global.exception.*;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -21,15 +14,10 @@ import java.util.*;
 
 @Service
 @RequiredArgsConstructor
-@Slf4j
+@Transactional(readOnly = true)
 public class ReviewService {
     private final ReviewRepository reviewRepository;
-    private final PostCategoryRepository postCategoryRepository;
-    private final CategoryRepository categoryRepository;
-    private final UserService userService;
-    private final NotificationService notificationService;
 
-    @Transactional(readOnly = true)
     public Post getPostByPostId(Long postId) {
         Optional<Post> post = reviewRepository.findById(postId);
         return post.orElseThrow(() -> new PostNotFoundException(ExceptionMessage.POST_NOT_FOUND.getMessage()));
@@ -63,7 +51,6 @@ public class ReviewService {
                 .build();
     }
 
-    @Transactional(readOnly = true)
     public List<PostDto> findByKeywordAndFilters(String keyword, String period, String type) {
         LocalDateTime startDate = DateUtil.getStartDate(period);
         LocalDateTime endDate = DateUtil.getCurrentDate();
@@ -72,43 +59,6 @@ public class ReviewService {
         List<Post> posts = reviewRepository.findByKeywordAndFilters(keyword, startDate, endDate, type);
 
         return getPostDtos(posts);
-    }
-
-    @Transactional
-    public Post save(PostDto postDto){
-
-        // 게시물 작성 폼에서 가져온 postCategory 제목으로 조회해서 PostCategory 리스트 생성
-        List<PostCategory> postCategories = postCategoryRepository.findByTitle(postDto.getPostCategoryTitle());
-
-        // 게시물 작성 폼에서 가져온 Category 제목으로 조회해서 Category 객체 생성
-        Category category = categoryRepository.findByTitle(postDto.getCategoryTitle())
-                .orElseThrow(() -> new CategoryNotFoundException(ExceptionMessage.CATEGORY_NOT_FOUND.getMessage()));
-
-        // 적절한 PostCategory 찾기
-        PostCategory postCategory = postCategories.stream()
-                .filter(pc -> pc.getCategory().equals(category))
-                .findFirst()
-                .orElseThrow(() -> new PostCategoryNotFoundException(ExceptionMessage.POST_CATEGORY_NOT_FOUND.getMessage()));
-
-        // 생성한 Category를 builder를 통해 연관관계 주입
-        PostCategory updatedPostCategory = postCategory.builder()
-                .id(postCategory.getId())
-                .title(postCategory.getTitle())
-                .category(category)
-                .build();
-
-        postDto.setUser(userService.getAuthenticatedUser()
-                .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage())));
-
-        // 주입된 PostCategory를 Post에 저장
-        Post post = PostDto.toEntity(postDto, updatedPostCategory);
-
-        Post savePost = reviewRepository.save(post);
-
-        // 알림 생성 로직 추가
-        notificationService.keywordsNotification(post);
-
-        return savePost;
     }
 
     @Transactional

--- a/src/main/java/com/inconcert/domain/post/service/TransferService.java
+++ b/src/main/java/com/inconcert/domain/post/service/TransferService.java
@@ -1,15 +1,9 @@
 package com.inconcert.domain.post.service;
 
-import com.inconcert.domain.category.entity.Category;
-import com.inconcert.domain.category.entity.PostCategory;
-import com.inconcert.domain.category.repository.CategoryRepository;
-import com.inconcert.domain.category.repository.PostCategoryRepository;
-import com.inconcert.domain.notification.service.NotificationService;
 import com.inconcert.domain.post.dto.PostDto;
 import com.inconcert.domain.post.entity.Post;
 import com.inconcert.domain.post.repository.TransferRepository;
 import com.inconcert.domain.post.util.DateUtil;
-import com.inconcert.domain.user.service.UserService;
 import com.inconcert.global.exception.*;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -20,14 +14,9 @@ import java.util.*;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class TransferService {
     private final TransferRepository transferRepository;
-    private final CategoryRepository categoryRepository;
-    private final PostCategoryRepository postCategoryRepository;
-    private final UserService userService;
-    private final NotificationService notificationService;
-
-    @Transactional(readOnly = true)
     public List<PostDto> getAllTransferPostsByPostCategory(String postCategoryTitle) {
         List<Post> posts = switch (postCategoryTitle) {
             case "musical" -> transferRepository.findPostsByPostCategoryTitle("musical");
@@ -40,7 +29,6 @@ public class TransferService {
         return getPostDtos(posts);
     }
 
-    @Transactional(readOnly = true)
     public Post getPostByPostId(Long postId) {
         Optional<Post> post = transferRepository.findById(postId);
         return post.orElseThrow(() -> new PostNotFoundException(ExceptionMessage.POST_NOT_FOUND.getMessage()));
@@ -83,43 +71,6 @@ public class TransferService {
         List<Post> posts = transferRepository.findByKeywordAndFilters(postCategoryTitle, keyword, startDate, endDate, type);
 
         return getPostDtos(posts);
-    }
-
-    @Transactional
-    public Post save(PostDto postDto){
-
-        // 게시물 작성 폼에서 가져온 postCategory 제목으로 조회해서 PostCategory 리스트 생성
-        List<PostCategory> postCategories = postCategoryRepository.findByTitle(postDto.getPostCategoryTitle());
-
-        // 게시물 작성 폼에서 가져온 Category 제목으로 조회해서 Category 객체 생성
-        Category category = categoryRepository.findByTitle(postDto.getCategoryTitle())
-                .orElseThrow(() -> new CategoryNotFoundException(ExceptionMessage.CATEGORY_NOT_FOUND.getMessage()));
-
-        // 적절한 PostCategory 찾기
-        PostCategory postCategory = postCategories.stream()
-                .filter(pc -> pc.getCategory().equals(category))
-                .findFirst()
-                .orElseThrow(() -> new PostCategoryNotFoundException(ExceptionMessage.POST_CATEGORY_NOT_FOUND.getMessage()));
-
-        // 생성한 Category를 builder를 통해 연관관계 주입
-        PostCategory updatedPostCategory = postCategory.builder()
-                .id(postCategory.getId())
-                .title(postCategory.getTitle())
-                .category(category)
-                .build();
-
-        postDto.setUser(userService.getAuthenticatedUser()
-                .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage())));
-
-        // 주입된 PostCategory를 Post에 저장
-        Post post = PostDto.toEntity(postDto, updatedPostCategory);
-
-        Post savePost = transferRepository.save(post);
-
-        // 알림 생성 로직 추가
-        notificationService.keywordsNotification(post);
-
-        return savePost;
     }
 
     @Transactional

--- a/src/main/java/com/inconcert/domain/post/service/WriteService.java
+++ b/src/main/java/com/inconcert/domain/post/service/WriteService.java
@@ -1,0 +1,85 @@
+package com.inconcert.domain.post.service;
+
+import com.inconcert.domain.category.entity.Category;
+import com.inconcert.domain.category.entity.PostCategory;
+import com.inconcert.domain.category.repository.CategoryRepository;
+import com.inconcert.domain.category.repository.PostCategoryRepository;
+import com.inconcert.domain.notification.service.NotificationService;
+import com.inconcert.domain.post.dto.PostDto;
+import com.inconcert.domain.post.entity.Post;
+import com.inconcert.domain.post.repository.InfoRepository;
+import com.inconcert.domain.post.repository.MatchRepository;
+import com.inconcert.domain.post.repository.ReviewRepository;
+import com.inconcert.domain.post.repository.TransferRepository;
+import com.inconcert.domain.user.service.UserService;
+import com.inconcert.global.exception.CategoryNotFoundException;
+import com.inconcert.global.exception.ExceptionMessage;
+import com.inconcert.global.exception.PostCategoryNotFoundException;
+import com.inconcert.global.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class WriteService {
+    private final PostCategoryRepository postCategoryRepository;
+    private final CategoryRepository categoryRepository;
+    private final UserService userService;
+    private final InfoRepository infoRepository;
+    private final MatchRepository matchRepository;
+    private final ReviewRepository reviewRepository;
+    private final TransferRepository transferRepository;
+    private final NotificationService notificationService;
+
+    @Transactional
+    public Post save(PostDto postDto){
+
+        // 게시물 작성 폼에서 가져온 postCategory 제목으로 조회해서 PostCategory 리스트 생성
+        List<PostCategory> postCategories = postCategoryRepository.findByTitle(postDto.getPostCategoryTitle());
+
+        // 게시물 작성 폼에서 가져온 Category 제목으로 조회해서 Category 객체 생성
+        Category category = categoryRepository.findByTitle(postDto.getCategoryTitle())
+                .orElseThrow(() -> new CategoryNotFoundException(ExceptionMessage.CATEGORY_NOT_FOUND.getMessage()));
+
+        // 적절한 PostCategory 찾기
+        PostCategory postCategory = postCategories.stream()
+                .filter(pc -> pc.getCategory().equals(category))
+                .findFirst()
+                .orElseThrow(() -> new PostCategoryNotFoundException(ExceptionMessage.POST_CATEGORY_COMBINATION_NOT_FOUND.getMessage()));
+
+        // 생성한 Category를 builder를 통해 연관관계 주입
+        PostCategory updatedPostCategory = postCategory.builder()
+                .id(postCategory.getId())
+                .title(postCategory.getTitle())
+                .category(category)
+                .build();
+
+        postDto.setUser(userService.getAuthenticatedUser()
+                .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage())));
+
+        // 동행을 제외한 카테고리들은 모집인원, 마감 날짜 제거
+        if(!category.equals("match")){
+            postDto.setMatchCount(0);
+            postDto.setEndDate(null);
+        }
+
+        // 주입된 PostCategory를 Post에 저장
+        Post post = PostDto.toEntity(postDto, updatedPostCategory);
+
+        Post savePost = switch (category.getTitle()) {
+            case "info" -> infoRepository.save(post);
+            case "review" -> reviewRepository.save(post);
+            case "match" -> matchRepository.save(post);
+            case "transfer" -> transferRepository.save(post);
+            default -> throw new CategoryNotFoundException(ExceptionMessage.CATEGORY_NOT_FOUND.getMessage());
+        };
+
+        // 알림 생성 로직 추가
+        notificationService.keywordsNotification(post);
+
+        return savePost;
+    }
+}

--- a/src/main/resources/templates/board/editform.html
+++ b/src/main/resources/templates/board/editform.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org/" lang="ko">
+<html xmlns:th="http://www.thymeleaf.org/" xmlns:sec="http://www.w3.org/1999/xhtml" lang="ko">
 <head>
     <meta charset="UTF-8">
     <title>게시글 수정</title>
@@ -18,7 +18,7 @@
         <div class="write-container">
             <div class="dropdowns">
                 <select id="categoryTitle" name="newCategoryTitle" required>
-                    <option value="info" th:selected="${categoryTitle == 'info'}">공연 소식</option>
+                    <option value="info" sec:authorize="hasRole('ROLE_ADMIN')" th:selected="${categoryTitle == 'info'}">공연 소식</option>
                     <option value="review" th:selected="${categoryTitle == 'review'}">공연 후기</option>
                     <option value="match" th:selected="${categoryTitle == 'match'}">동행</option>
                     <option value="transfer" th:selected="${categoryTitle == 'transfer'}">양도</option>
@@ -33,7 +33,7 @@
             </div>
 
             <div class="dropdowns">
-                <select id="matchCount" name="matchCount" th:field="*{matchCount}" required>
+                <select id="matchCount" name="matchCount" th:field="${post.matchCount}" required>
                     <option value="1">1</option>
                     <option value="2">2</option>
                     <option value="3">3</option>
@@ -41,7 +41,7 @@
                 </select>
                 <div class="date-container">
                     <label for="endDate">종료 날짜 지정</label>
-                    <input type="date" id="endDate" name="endDate" th:field="*{endDate}" required>
+                    <input type="date" id="endDate" name="endDate" th:value="${post.endDate}" required>
                 </div>
             </div>
 

--- a/src/main/resources/templates/board/editform.html
+++ b/src/main/resources/templates/board/editform.html
@@ -6,6 +6,39 @@
     <link rel="stylesheet" href="/css/board/writeform.css">
     <link href="https://cdn.quilljs.com/1.3.6/quill.snow.css" rel="stylesheet">
     <script src="https://cdn.quilljs.com/1.3.6/quill.min.js"></script>
+    <script>
+        function validateSearch() {
+            let keyword = document.getElementById("search-input").value.trim();
+            if (keyword.length < 2) {
+                alert("검색어를 2자 이상 입력하세요.");
+                return false;
+            }
+            return true;
+        }
+
+        function toggleMatchAndDateFields() {
+            const categoryTitle = document.getElementById("categoryTitle");
+            const matchCount = document.getElementById("matchCount");
+            const endDate = document.getElementById("endDate");
+            const dateContainer = document.querySelector(".date-container");
+
+            if (categoryTitle.value === "match") {
+                matchCount.style.display = "block";
+                dateContainer.style.display = "flex";
+            } else {
+                matchCount.style.display = "none";
+                dateContainer.style.display = "none";
+            }
+        }
+
+        document.addEventListener("DOMContentLoaded", function() {
+            const categoryTitle = document.getElementById("categoryTitle");
+            categoryTitle.addEventListener("change", toggleMatchAndDateFields);
+
+            // 페이지 로드 시 초기 상태 설정
+            toggleMatchAndDateFields();
+        });
+    </script>
 </head>
 <body>
 <div class="container">
@@ -33,7 +66,7 @@
             </div>
 
             <div class="dropdowns">
-                <select id="matchCount" name="matchCount" th:field="${post.matchCount}" required>
+                <select id="matchCount" name="matchCount" th:field="${post.matchCount}">
                     <option value="1">1</option>
                     <option value="2">2</option>
                     <option value="3">3</option>
@@ -41,7 +74,7 @@
                 </select>
                 <div class="date-container">
                     <label for="endDate">종료 날짜 지정</label>
-                    <input type="date" id="endDate" name="endDate" th:value="${post.endDate}" required>
+                    <input type="date" id="endDate" name="endDate" th:value="${post.endDate}">
                 </div>
             </div>
 
@@ -111,14 +144,17 @@
     document.getElementById('editForm').addEventListener('submit', function(event) {
         document.getElementById('content').value = quill.root.innerHTML;
 
+        var categoryTitle = document.getElementById('categoryTitle');
+        var postCategoryTitle = document.getElementById('postCategoryTitle');
         var matchCount = document.getElementById('matchCount');
         var endDate = document.getElementById('endDate');
         var title = document.getElementById('title');
         var content = document.getElementById('content');
 
         if (
-            matchCount.value === 'default' ||
-            !endDate.value ||
+            categoryTitle.value === 'default' ||
+            postCategoryTitle.value === 'default' ||
+            (categoryTitle.value === 'match' && (matchCount.value === 'default' || !endDate.value)) ||
             !title.value.trim() ||
             !content.value.trim()
         ) {

--- a/src/main/resources/templates/board/writeform.html
+++ b/src/main/resources/templates/board/writeform.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns:th="http://www.thymeleaf.org/" lang="ko">
+<html xmlns:th="http://www.thymeleaf.org/" xmlns:sec="http://www.w3.org/1999/xhtml" lang="ko">
 <head>
     <meta charset="UTF-8">
     <title>메인 화면</title>
@@ -26,7 +26,7 @@
             <div class="dropdowns">
                 <select id="categoryTitle" name="categoryTitle" required>
                     <option disabled selected value="default">게시판 선택</option>
-                    <option value="info">공연 소식</option>
+                    <option sec:authorize="hasRole('ROLE_ADMIN')" value="info">공연 소식</option>
                     <option value="review">공연 후기</option>
                     <option value="match">동행</option>
                     <option value="transfer">양도</option>

--- a/src/main/resources/templates/board/writeform.html
+++ b/src/main/resources/templates/board/writeform.html
@@ -15,6 +15,28 @@
             }
             return true;
         }
+
+        function toggleMatchAndDateFields() {
+            const categoryTitle = document.getElementById("categoryTitle");
+            const matchCount = document.getElementById("matchCount");
+            const dateContainer = document.querySelector(".date-container");
+
+            if (categoryTitle.value === "match") {
+                matchCount.style.display = "block";
+                dateContainer.style.display = "flex";
+            } else {
+                matchCount.style.display = "none";
+                dateContainer.style.display = "none";
+            }
+        }
+
+        document.addEventListener("DOMContentLoaded", function() {
+            const categoryTitle = document.getElementById("categoryTitle");
+            categoryTitle.addEventListener("change", toggleMatchAndDateFields);
+
+            // 페이지 로드 시 초기 상태 설정
+            toggleMatchAndDateFields();
+        });
     </script>
 </head>
 <body>
@@ -42,16 +64,16 @@
             </div>
 
             <div class="dropdowns">
-                <select id="matchCount" name="matchCount" required>
+                <select id="matchCount" name="matchCount" style="display:none;">
                     <option disabled selected value="default">모집인원 선택</option>
                     <option value="1">1</option>
                     <option value="2">2</option>
                     <option value="3">3</option>
                     <option value="4">4</option>
                 </select>
-                <div class="date-container">
+                <div class="date-container" style="display:none;">
                     <label for="endDate">종료 날짜 지정</label>
-                    <input type="date" id="endDate" name="endDate" required>
+                    <input type="date" id="endDate" name="endDate">
                 </div>
             </div>
 
@@ -127,8 +149,7 @@
         if (
             categoryTitle.value === 'default' ||
             postCategoryTitle.value === 'default' ||
-            matchCount.value === 'default' ||
-            !endDate.value ||
+            (categoryTitle.value === 'match' && (matchCount.value === 'default' || !endDate.value)) ||
             !title.value.trim() ||
             !content.value.trim()
         ) {


### PR DESCRIPTION
## 요약 #21
- 글 작성 및 수정 시 동행 글 선택 로직, 종료날짜 불러오기, 관리자만 공연 소식 글 작성 가능

## 추가사항
- 공연 소식 선택란에 sec 이용해 관리자만 작성 가능하게 변경

## 수정사항
- 수정 시 종료날짜 못 불러오는 오류 해결
- 각각의 save 서비스를 WriteService로 분리
- 동행 카테고리를 선택한 경우에만 모집인원, 마감날짜 입력 란 표시

<br>

- [ ✅ ] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ✅ ] 🧹 불필요한 코드는 제거했나요?
- [ ✅ ] 💭 (선택) 이슈는 등록했나요?
- [ ✅ ] 🏷️ 라벨은 등록했나요?
- [ ✅ ] 💻 git rebase를 사용했나요?