### PR TITLE
[Feat]: 동행 종료 및 상호평가 로직

### DIFF
--- a/src/main/java/com/inconcert/domain/chat/controller/ChatApiController.java
+++ b/src/main/java/com/inconcert/domain/chat/controller/ChatApiController.java
@@ -103,9 +103,10 @@ public class ChatApiController {
         try {
             ChatRoom chatRoom = chatService.createOneToOneChatRoom(receiverId);
             return ResponseEntity.ok(chatRoom.getId()); // 채팅방 ID 반환
-        }
-        catch (AlreadyInChatRoomException e) {
-            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage()); // 이미 존재하는 경우 메시지 반환
+        } catch (AlreadyInChatRoomException e) {
+            return ResponseEntity.status(HttpStatus.CONFLICT).body(e.getMessage());     // 이미 존재하는 경우 메시지 반환
+        } catch (SelfChatException e) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(e.getMessage());  // 본인에게 1대1 채팅을 보내는 경우
         }
     }
 

--- a/src/main/java/com/inconcert/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/inconcert/domain/chat/repository/ChatRoomRepository.java
@@ -1,7 +1,10 @@
 package com.inconcert.domain.chat.repository;
 
 import com.inconcert.domain.chat.entity.ChatRoom;
+import com.inconcert.domain.user.dto.response.MatchRspDTO;
 import com.inconcert.domain.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -23,4 +26,12 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     // 채팅방에 속한 유저 목록
     @Query("select c.users from ChatRoom c where c.id = :chatRoomId")
     List<User> findAllById(@Param("chatRoomId") Long chatRoomId);
+
+    ChatRoom findByPostId(Long postId);
+
+    @Query("SELECT new com.inconcert.domain.user.dto.response.MatchRspDTO" +
+            "(c.post.id, c.id, c.post.title, c.post.endDate, size(c.users), c.post.matchCount, c.post.isEnd, c.post.thumbnailUrl, c.post.postCategory.category.title, c.post.postCategory.title, c.hostUser.nickname) " +
+            "FROM ChatRoom c JOIN c.users u " +
+            "WHERE u.id = :userId AND c.post.isEnd = false")
+    Page<MatchRspDTO> findAllByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/inconcert/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/inconcert/domain/chat/repository/ChatRoomRepository.java
@@ -27,7 +27,10 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     @Query("select c.users from ChatRoom c where c.id = :chatRoomId")
     List<User> findAllById(@Param("chatRoomId") Long chatRoomId);
 
-    ChatRoom findByPostId(Long postId);
+    @Query("SELECT u.id " +
+            "FROM ChatRoom c JOIN c.users u " +
+            "WHERE c.post.id = :postId")
+    List<Long> findUserIdsByPostId(@Param("postId") Long postId);
 
     @Query("SELECT new com.inconcert.domain.user.dto.response.MatchRspDTO" +
             "(c.post.id, c.id, c.post.title, c.post.endDate, size(c.users), c.post.matchCount, c.post.isEnd, c.post.thumbnailUrl, c.post.postCategory.category.title, c.post.postCategory.title, c.hostUser.nickname) " +

--- a/src/main/java/com/inconcert/domain/feedback/entity/Feedback.java
+++ b/src/main/java/com/inconcert/domain/feedback/entity/Feedback.java
@@ -1,0 +1,40 @@
+package com.inconcert.domain.feedback.entity;
+
+import com.inconcert.domain.post.entity.Post;
+import com.inconcert.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "feedbacks")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Feedback{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private int point;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User reviewer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User reviewee;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Post post;
+
+    public Feedback(int point, User reviewer, User reviewee, Post post) {
+        this.point = point;
+        this.reviewer = reviewer;
+        this.reviewee = reviewee;
+        this.post = post;
+    }
+}

--- a/src/main/java/com/inconcert/domain/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/com/inconcert/domain/feedback/repository/FeedbackRepository.java
@@ -1,0 +1,17 @@
+package com.inconcert.domain.feedback.repository;
+
+import com.inconcert.domain.feedback.entity.Feedback;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
+    @Query("SELECT f.reviewee.id " +
+            "FROM Feedback f " +
+            "WHERE f.reviewer.id = :reviewerId AND f.reviewee.id IN :revieweeIds AND f.post.id = :postId")
+    List<Long> findExistingFeedbacks(@Param("reviewerId") Long reviewerId,
+                                     @Param("revieweeIds") List<Long> revieweeIds,
+                                     @Param("postId") Long postId);
+}

--- a/src/main/java/com/inconcert/domain/feedback/service/FeedbackService.java
+++ b/src/main/java/com/inconcert/domain/feedback/service/FeedbackService.java
@@ -1,0 +1,37 @@
+package com.inconcert.domain.feedback.service;
+
+import com.inconcert.domain.post.entity.Post;
+import com.inconcert.domain.post.repository.MatchRepository;
+import com.inconcert.domain.feedback.entity.Feedback;
+import com.inconcert.domain.feedback.repository.FeedbackRepository;
+import com.inconcert.domain.user.entity.User;
+import com.inconcert.domain.user.repository.UserRepository;
+import com.inconcert.global.exception.ExceptionMessage;
+import com.inconcert.global.exception.PostNotFoundException;
+import com.inconcert.global.exception.UserNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FeedbackService {
+    private final FeedbackRepository feedbackRepository;
+    private final UserRepository userRepository;
+    private final MatchRepository matchRepository;
+
+
+    public void feedback(Long postId, Long reviewerId, Long revieweeId, int point){
+        Post post = matchRepository.findById(postId)
+                .orElseThrow(() -> new PostNotFoundException(ExceptionMessage.POST_NOT_FOUND.getMessage()));
+
+        User reviewer = userRepository.findById(reviewerId)
+                .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+
+        User reviewee = userRepository.findById(revieweeId)
+                .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+
+        Feedback feedback = new Feedback(point, reviewer, reviewee, post);
+
+        feedbackRepository.save(feedback);
+    }
+}

--- a/src/main/java/com/inconcert/domain/post/config/SchedulingConfig.java
+++ b/src/main/java/com/inconcert/domain/post/config/SchedulingConfig.java
@@ -1,0 +1,9 @@
+package com.inconcert.domain.post.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+@Configuration
+@EnableScheduling
+public class SchedulingConfig {
+}

--- a/src/main/java/com/inconcert/domain/post/controller/MatchController.java
+++ b/src/main/java/com/inconcert/domain/post/controller/MatchController.java
@@ -145,6 +145,14 @@ public class MatchController {
         return "redirect:/" + newCategoryTitle + '/' + newPostCategoryTitle + '/' + updatedPostId;
     }
 
+    @PostMapping("/{postCategoryTitle}/{postId}/complete")
+    public String completeMatch(@PathVariable("postId") Long postId,
+                                @PathVariable("postCategoryTitle") String postCategoryTitle) {
+
+            matchService.completeMatch(postId);
+        return "redirect:/match/" + postCategoryTitle + '/' + postId;
+    }
+
     @PostMapping("/write")
     public String write(@ModelAttribute PostDTO postDto) {
         Post post = writeService.save(postDto);

--- a/src/main/java/com/inconcert/domain/post/dto/PostDTO.java
+++ b/src/main/java/com/inconcert/domain/post/dto/PostDTO.java
@@ -23,6 +23,7 @@ public class PostDTO {
     private String postCategoryTitle;
     private LocalDate endDate;
     private Long chatRoomId;
+    private int chatRoomUserSize;
     private int matchCount;
     private String content;
     private String thumbnailUrl;
@@ -35,6 +36,7 @@ public class PostDTO {
     private boolean isNew;
     private LocalDateTime createdAt;
     private User user;
+    private boolean isEnd;
 
     // post 저장
     public static Post toEntity(PostDTO postDto, PostCategory postCategory) {

--- a/src/main/java/com/inconcert/domain/post/entity/Post.java
+++ b/src/main/java/com/inconcert/domain/post/entity/Post.java
@@ -44,6 +44,12 @@ public class Post extends BaseEntity {
     @Column(name = "view_count")
     private int viewCount = 0;
 
+    @Column(name = "is_end")
+    private boolean isEnd = false;
+
+    @ElementCollection
+    private List<Long> matchUserIds = new ArrayList<>();
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
@@ -78,5 +84,13 @@ public class Post extends BaseEntity {
 
     public boolean hasChatRoom() {
         return this.chatRoom != null;
+    }
+
+    public void toggleIsEnd(){
+        this.isEnd = !this.isEnd;
+    }
+
+    public void updateMatchUserIds(List<Long> matchUserIds) {
+        this.matchUserIds = matchUserIds;
     }
 }

--- a/src/main/java/com/inconcert/domain/post/repository/MatchRepository.java
+++ b/src/main/java/com/inconcert/domain/post/repository/MatchRepository.java
@@ -79,8 +79,10 @@ public interface MatchRepository extends JpaRepository<Post, Long> {
                                           @Param("mbti") Mbti mbti,
                                           Pageable pageable);
 
-    @Query("SELECT p FROM Post p WHERE p.endDate < :currentDate AND p.isEnd = true AND p.postCategory.category.title = 'match'")
-    List<Post> findAllByEndDateBeforeAndIsEndFalse(@Param("currentDate") LocalDate currentDate);
+    @Query("SELECT p.id " +
+            "FROM Post p " +
+            "WHERE p.endDate < :currentDate AND p.isEnd = false AND p.postCategory.category.title = 'match'")
+    List<Long> findAllByEndDateBeforeAndIsEndFalse(@Param("currentDate") LocalDate currentDate);
 
     @Query("SELECT new com.inconcert.domain.user.dto.response.MatchRspDTO" +
             "(p.id, p.chatRoom.id, p.title, p.endDate, size(p.chatRoom.users), p.matchCount, p.isEnd, p.thumbnailUrl, p.postCategory.category.title, p.postCategory.title, p.chatRoom.hostUser.nickname) " +

--- a/src/main/java/com/inconcert/domain/post/service/InfoService.java
+++ b/src/main/java/com/inconcert/domain/post/service/InfoService.java
@@ -78,11 +78,6 @@ public class InfoService {
                 .build();
     }
 
-    public Post getPostByPostId(Long postId) {
-        return infoRepository.findById(postId)
-                .orElseThrow(() -> new PostNotFoundException(ExceptionMessage.POST_NOT_FOUND.getMessage()));
-    }
-
     @Transactional
     public void deletePost(Long postId) {
         Post post = infoRepository.findById(postId)

--- a/src/main/java/com/inconcert/domain/post/service/ReviewService.java
+++ b/src/main/java/com/inconcert/domain/post/service/ReviewService.java
@@ -64,12 +64,6 @@ public class ReviewService {
                 .build();
     }
 
-    @Transactional(readOnly = true)
-    public Post getPostByPostId(Long postId) {
-        Optional<Post> post = reviewRepository.findById(postId);
-        return post.orElseThrow(() -> new PostNotFoundException(ExceptionMessage.POST_NOT_FOUND.getMessage()));
-    }
-
     @Transactional
     public void deletePost(Long postId) {
         Post post = reviewRepository.findById(postId)

--- a/src/main/java/com/inconcert/domain/post/service/ReviewService.java
+++ b/src/main/java/com/inconcert/domain/post/service/ReviewService.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.*;
-import java.util.*;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/inconcert/domain/post/service/TransferService.java
+++ b/src/main/java/com/inconcert/domain/post/service/TransferService.java
@@ -75,12 +75,6 @@ public class TransferService {
                 .build();
     }
 
-    @Transactional(readOnly = true)
-    public Post getPostByPostId(Long postId) {
-        Optional<Post> post = transferRepository.findById(postId);
-        return post.orElseThrow(() -> new PostNotFoundException(ExceptionMessage.POST_NOT_FOUND.getMessage()));
-    }
-
     @Transactional
     public void deletePost(Long postId) {
         Post post = transferRepository.findById(postId)

--- a/src/main/java/com/inconcert/domain/user/controller/MyPageController.java
+++ b/src/main/java/com/inconcert/domain/user/controller/MyPageController.java
@@ -120,9 +120,11 @@ public class MyPageController {
                                      @RequestParam(name = "size", defaultValue = "10") int size) {
 
         Page<MatchRspDTO> matchRspDTOS = myPageService.presentMatch(userId, page, size);
+        User user = userService.getAuthenticatedUser()
+                .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+
         model.addAttribute("matchRspDTOs", matchRspDTOS);
-        model.addAttribute("user", userService.getAuthenticatedUser()
-                .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage())));
+        model.addAttribute("user", user);
         model.addAttribute("activeTab", "present");
         model.addAttribute("currentPage", page);
         model.addAttribute("totalPages", matchRspDTOS.getTotalPages());
@@ -137,23 +139,20 @@ public class MyPageController {
                                       @RequestParam(name = "size", defaultValue = "10") int size) {
 
         Page<MatchRspDTO> matchRspDTOS = myPageService.completeMatch(userId, page, size);
+        User user = userService.getAuthenticatedUser()
+                .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+        List<Boolean> isEndFeedback = myPageService.isEndFeedback(userId, matchRspDTOS
+                .stream()
+                .map(MatchRspDTO::getPostId)
+                .collect(Collectors.toList()));
+
         model.addAttribute("matchRspDTOs", matchRspDTOS);
-        model.addAttribute("user", userService.getAuthenticatedUser()
-                .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage())));
+        model.addAttribute("user", user);
         model.addAttribute("activeTab", "complete");
         model.addAttribute("currentPage", page);
         model.addAttribute("totalPages", matchRspDTOS.getTotalPages());
-        model.addAttribute("isEndFeedback", myPageService.isEndFeedback(userId, matchRspDTOS
-                .stream()
-                .map(MatchRspDTO::getPostId)
-                .collect(Collectors.toList())));
+        model.addAttribute("isEndFeedback", isEndFeedback);
 
-        for (boolean b : myPageService.isEndFeedback(userId, matchRspDTOS
-                .stream()
-                .map(MatchRspDTO::getPostId)
-                .collect(Collectors.toList()))){
-            System.out.println(b);
-        }
         return "/user/match-list";
     }
 
@@ -163,6 +162,10 @@ public class MyPageController {
                                  @PathVariable(name = "postId") Long postId) {
         List<FeedbackRspDTO> myReviewee = myPageService.getMyReviewee(userId, postId);
         List<Boolean> myReviewStatuses = myPageService.getUsersReviewStatuses(userId, postId);
+        User user = userService.getAuthenticatedUser()
+                .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+
+        model.addAttribute("user", user);
         model.addAttribute("myReviewee", myReviewee);
         model.addAttribute("myReviewStatuses", myReviewStatuses);
         return "/user/review-list";

--- a/src/main/java/com/inconcert/domain/user/controller/MyPageController.java
+++ b/src/main/java/com/inconcert/domain/user/controller/MyPageController.java
@@ -1,20 +1,28 @@
 package com.inconcert.domain.user.controller;
 
 import com.inconcert.domain.post.dto.PostDTO;
+import com.inconcert.domain.feedback.service.FeedbackService;
 import com.inconcert.domain.user.dto.request.MyPageEditReqDto;
+import com.inconcert.domain.user.dto.response.MatchRspDTO;
+import com.inconcert.domain.user.dto.response.FeedbackRspDTO;
 import com.inconcert.domain.user.entity.Mbti;
 import com.inconcert.domain.user.entity.User;
 import com.inconcert.domain.user.service.MyPageService;
 import com.inconcert.domain.user.service.UserService;
 import com.inconcert.global.exception.ExceptionMessage;
+import com.inconcert.global.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.mvc.support.RedirectAttributes;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Controller
 @RequestMapping("/mypage")
@@ -22,12 +30,14 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 public class MyPageController {
     private final UserService userService;
     private final MyPageService myPageService;
+    private final FeedbackService feedbackService;
 
     @GetMapping
     public String mypage(Model model) {
         User user = userService.getAuthenticatedUser()
                 .orElseThrow(() -> new UsernameNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
         model.addAttribute("user", user);
+
         return "/user/mypage";
     }
 
@@ -37,6 +47,7 @@ public class MyPageController {
                 .orElseThrow(() -> new UsernameNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
         model.addAttribute("user", user);
         model.addAttribute("mbtiValues", Mbti.values());
+
         return "/user/mypageedit";
     }
 
@@ -98,21 +109,74 @@ public class MyPageController {
         model.addAttribute("currentPage", page);
         model.addAttribute("totalPages", postPage.getTotalPages());
         model.addAttribute("title", "like");
+
         return "/user/mypage-detail";
     }
 
-    // 이건 그냥 작성해놓은 거임
-    @GetMapping("/with/{userId}")
-    public String showMyWith(Model model,
-                             @PathVariable("userId") Long userId,
-                             @RequestParam(name = "page", defaultValue = "0") int page,
-                             @RequestParam(name = "size", defaultValue = "10") int size) {
-        Page<PostDTO> postPage = myPageService.getMyPosts(userId, page, size);
-        model.addAttribute("postsPage", postPage);
+    @GetMapping("/match/{userId}/present")
+    public String showMyPresentMatch(Model model,
+                                     @PathVariable(name = "userId") Long userId,
+                                     @RequestParam(name = "page", defaultValue = "0") int page,
+                                     @RequestParam(name = "size", defaultValue = "10") int size) {
+
+        Page<MatchRspDTO> matchRspDTOS = myPageService.presentMatch(userId, page, size);
+        model.addAttribute("matchRspDTOs", matchRspDTOS);
+        model.addAttribute("user", userService.getAuthenticatedUser()
+                .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage())));
+        model.addAttribute("activeTab", "present");
         model.addAttribute("currentPage", page);
-        model.addAttribute("totalPages", postPage.getTotalPages());
-        model.addAttribute("title", "with");
-        return "/user/mypage-detail";
+        model.addAttribute("totalPages", matchRspDTOS.getTotalPages());
+
+        return "/user/match-list";
+    }
+
+    @GetMapping("/match/{userId}/complete")
+    public String showMyCompleteMatch(Model model,
+                                      @PathVariable(name = "userId") Long userId,
+                                      @RequestParam(name = "page", defaultValue = "0") int page,
+                                      @RequestParam(name = "size", defaultValue = "10") int size) {
+
+        Page<MatchRspDTO> matchRspDTOS = myPageService.completeMatch(userId, page, size);
+        model.addAttribute("matchRspDTOs", matchRspDTOS);
+        model.addAttribute("user", userService.getAuthenticatedUser()
+                .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage())));
+        model.addAttribute("activeTab", "complete");
+        model.addAttribute("currentPage", page);
+        model.addAttribute("totalPages", matchRspDTOS.getTotalPages());
+        model.addAttribute("isEndFeedback", myPageService.isEndFeedback(userId, matchRspDTOS
+                .stream()
+                .map(MatchRspDTO::getPostId)
+                .collect(Collectors.toList())));
+
+        for (boolean b : myPageService.isEndFeedback(userId, matchRspDTOS
+                .stream()
+                .map(MatchRspDTO::getPostId)
+                .collect(Collectors.toList()))){
+            System.out.println(b);
+        }
+        return "/user/match-list";
+    }
+
+    @GetMapping("/match/{userId}/complete/{postId}")
+    public String showMyReviewee(Model model,
+                                 @PathVariable(name = "userId") Long userId,
+                                 @PathVariable(name = "postId") Long postId) {
+        List<FeedbackRspDTO> myReviewee = myPageService.getMyReviewee(userId, postId);
+        List<Boolean> myReviewStatuses = myPageService.getUsersReviewStatuses(userId, postId);
+        model.addAttribute("myReviewee", myReviewee);
+        model.addAttribute("myReviewStatuses", myReviewStatuses);
+        return "/user/review-list";
+    }
+
+    @PostMapping("/match/{reviewerId}/complete/{postId}/{revieweeId}")
+    public ResponseEntity<?> addMyfeedback(@PathVariable(name = "reviewerId") Long reviewerId,
+                                @PathVariable(name = "revieweeId") Long revieweeId,
+                                @PathVariable(name = "postId") Long postId,
+                                @RequestParam(name = "rating") int rating) {
+
+        feedbackService.feedback(postId, reviewerId, revieweeId, rating);
+
+        return ResponseEntity.ok().build();
     }
 
     @PostMapping("/bye")

--- a/src/main/java/com/inconcert/domain/user/dto/request/FeedbackReqDTO.java
+++ b/src/main/java/com/inconcert/domain/user/dto/request/FeedbackReqDTO.java
@@ -1,0 +1,12 @@
+package com.inconcert.domain.user.dto.request;
+
+import lombok.*;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedbackReqDTO {
+    private int point;
+}

--- a/src/main/java/com/inconcert/domain/user/dto/response/FeedbackRspDTO.java
+++ b/src/main/java/com/inconcert/domain/user/dto/response/FeedbackRspDTO.java
@@ -21,12 +21,14 @@ public class FeedbackRspDTO {
     private Mbti mbti;
     private Gender gender;
 
-    public FeedbackRspDTO(Long revieweeId, String profileImage, String nickname, LocalDate birth, Mbti mbti, Gender gender) {
+    public FeedbackRspDTO(Long revieweeId, String profileImage, String nickname, LocalDate birth, Mbti mbti, Gender gender, Long reviewerId, Long postId) {
         this.revieweeId = revieweeId;
         this.profileImage = profileImage;
         this.nickname = nickname;
         this.birth = birth;
         this.mbti = mbti;
         this.gender = gender;
+        this.reviewerId = reviewerId;
+        this.postId = postId;
     }
 }

--- a/src/main/java/com/inconcert/domain/user/dto/response/FeedbackRspDTO.java
+++ b/src/main/java/com/inconcert/domain/user/dto/response/FeedbackRspDTO.java
@@ -1,0 +1,32 @@
+package com.inconcert.domain.user.dto.response;
+
+import com.inconcert.domain.user.entity.Gender;
+import com.inconcert.domain.user.entity.Mbti;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedbackRspDTO {
+    private Long reviewerId;
+    private Long revieweeId;
+    private Long postId;
+    private String profileImage;
+    private String nickname;
+    private LocalDate birth;
+    private Mbti mbti;
+    private Gender gender;
+
+    public FeedbackRspDTO(Long revieweeId, String profileImage, String nickname, LocalDate birth, Mbti mbti, Gender gender) {
+        this.revieweeId = revieweeId;
+        this.profileImage = profileImage;
+        this.nickname = nickname;
+        this.birth = birth;
+        this.mbti = mbti;
+        this.gender = gender;
+    }
+}

--- a/src/main/java/com/inconcert/domain/user/dto/response/MatchRspDTO.java
+++ b/src/main/java/com/inconcert/domain/user/dto/response/MatchRspDTO.java
@@ -1,0 +1,41 @@
+package com.inconcert.domain.user.dto.response;
+
+import com.inconcert.domain.user.entity.User;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MatchRspDTO {
+    private Long postId;
+    private Long chatRoomId;
+    private String title;
+    private LocalDate endDate;
+    private int chatRoomUserSize;
+    private int matchCount;
+    private boolean isEnd;
+    private String thumbnailUrl;
+    private String categoryTitle;
+    private String postCategoryTitle;
+    private String hostNickname;
+    private List<User> matchUsers;
+
+    public MatchRspDTO(Long postId, Long chatRoomId, String title, LocalDate endDate, int chatRoomUserSize, int matchCount, boolean isEnd, String thumbnailUrl, String categoryTitle, String postCategoryTitle, String hostNickname) {
+        this.postId = postId;
+        this.chatRoomId = chatRoomId;
+        this.title = title;
+        this.endDate = endDate;
+        this.chatRoomUserSize = chatRoomUserSize;
+        this.matchCount = matchCount;
+        this.isEnd = isEnd;
+        this.thumbnailUrl = thumbnailUrl;
+        this.categoryTitle = categoryTitle;
+        this.postCategoryTitle = postCategoryTitle;
+        this.hostNickname = hostNickname;
+    }
+}

--- a/src/main/java/com/inconcert/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/inconcert/domain/user/repository/UserRepository.java
@@ -1,9 +1,13 @@
 package com.inconcert.domain.user.repository;
 
+import com.inconcert.domain.user.dto.response.FeedbackRspDTO;
 import com.inconcert.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -17,4 +21,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByNameAndEmail(String name, String email);
     Optional<User> findByUsernameAndEmail(String username, String email);
+
+    @Query("SELECT new com.inconcert.domain.user.dto.response.FeedbackRspDTO" +
+            "(u.id, u.profileImage, u.nickname, u.birth, u.mbti, u.gender) " +
+            "FROM User u " +
+            "WHERE u.id IN :matchUserIds AND u.id != :userId")
+    List<FeedbackRspDTO> getFeedbackRspDTOByMatchUserIds(@Param("userId") Long userId, @Param("matchUserIds") List<Long> matchUserIds);
+
+
 }

--- a/src/main/java/com/inconcert/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/inconcert/domain/user/repository/UserRepository.java
@@ -23,10 +23,12 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsernameAndEmail(String username, String email);
 
     @Query("SELECT new com.inconcert.domain.user.dto.response.FeedbackRspDTO" +
-            "(u.id, u.profileImage, u.nickname, u.birth, u.mbti, u.gender) " +
+            "(u.id, u.profileImage, u.nickname, u.birth, u.mbti, u.gender, :userId, :postId) " +
             "FROM User u " +
-            "WHERE u.id IN :matchUserIds AND u.id != :userId")
-    List<FeedbackRspDTO> getFeedbackRspDTOByMatchUserIds(@Param("userId") Long userId, @Param("matchUserIds") List<Long> matchUserIds);
+            "WHERE u.id IN :matchUserIds")
+    List<FeedbackRspDTO> getFeedbackRspDTOByMatchUserIds(@Param("userId") Long userId,
+                                                         @Param("postId") Long postId,
+                                                         @Param("matchUserIds") List<Long> matchUserIds);
 
 
 }

--- a/src/main/java/com/inconcert/domain/user/service/MyPageService.java
+++ b/src/main/java/com/inconcert/domain/user/service/MyPageService.java
@@ -1,12 +1,19 @@
 package com.inconcert.domain.user.service;
 
+import com.inconcert.domain.chat.repository.ChatRoomRepository;
 import com.inconcert.domain.post.dto.PostDTO;
+import com.inconcert.domain.post.entity.Post;
+import com.inconcert.domain.post.repository.MatchRepository;
 import com.inconcert.domain.post.service.ImageService;
+import com.inconcert.domain.feedback.repository.FeedbackRepository;
 import com.inconcert.domain.user.dto.request.MyPageEditReqDto;
+import com.inconcert.domain.user.dto.response.MatchRspDTO;
+import com.inconcert.domain.user.dto.response.FeedbackRspDTO;
 import com.inconcert.domain.user.entity.User;
 import com.inconcert.domain.user.repository.MyPageRepostory;
 import com.inconcert.domain.user.repository.UserRepository;
 import com.inconcert.global.exception.ExceptionMessage;
+import com.inconcert.global.exception.PostNotFoundException;
 import com.inconcert.global.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -16,7 +23,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +36,9 @@ public class MyPageService {
     private final UserService userService;
     private final ImageService imageService;
     private final PasswordEncoder passwordEncoder;
+    private final MatchRepository matchRepository;
+    private final ChatRoomRepository chatRoomRepository;
+    private final FeedbackRepository feedbackRepository;
 
     @Transactional(readOnly = true)
     public Page<PostDTO> getMyPosts(Long userId, int page, int size) {
@@ -66,5 +79,69 @@ public class MyPageService {
 
         user.updateUser(reqDto, encodedPassword, profileImageUrl);
         userRepository.save(user);
+    }
+
+    // 동행중
+    public Page<MatchRspDTO> presentMatch(Long userId, int page, int size){
+        Pageable pageable = PageRequest.of(page, size);
+
+        return chatRoomRepository.findAllByUserId(userId, pageable);
+    }
+
+    // 동행 완료
+    public Page<MatchRspDTO> completeMatch(Long userId, int page, int size){
+        Pageable pageable = PageRequest.of(page, size);
+
+        return matchRepository.findAllByUserIdANDEndMatch(userId, pageable);
+    }
+
+
+    public List<FeedbackRspDTO> getMyReviewee(Long userId, Long postId){
+        Post post = matchRepository.findById(postId)
+                .orElseThrow(() -> new PostNotFoundException(ExceptionMessage.POST_NOT_FOUND.getMessage()));
+
+        List<FeedbackRspDTO> feedbackRspDTOs = userRepository.getFeedbackRspDTOByMatchUserIds(userId, post.getMatchUserIds());
+
+        feedbackRspDTOs.forEach(dto -> {
+            dto.setReviewerId(userId);
+            dto.setPostId(postId);
+        });
+
+        return feedbackRspDTOs;
+    }
+
+    public List<Boolean> getUsersReviewStatuses(Long userId, Long postId){
+        Post post = matchRepository.findById(postId)
+                .orElseThrow(() -> new PostNotFoundException(ExceptionMessage.POST_NOT_FOUND.getMessage()));
+
+        List<Long> matchUserIds = post.getMatchUserIds().stream()
+                .filter(id -> !id.equals(userId))
+                .collect(Collectors.toList());
+
+        List<Long> revieweeIds = feedbackRepository.findExistingFeedbacks(userId, matchUserIds, postId);
+
+        // admin이랑 user1을 돌아
+        return matchUserIds.stream()
+                // adminId가 이미 리뷰완료 Id에 포함돼 ?
+                .map(id -> revieweeIds.contains(id))
+                .collect(Collectors.toList());
+    }
+
+    public List<Boolean> isEndFeedback(Long userId, List<Long> postIds){
+        List<Boolean> result = new ArrayList<>();
+        for(Long postId : postIds){
+            List<Boolean> usersReviewStatuses = getUsersReviewStatuses(userId, postId);
+
+            boolean flag = true;
+            for (Boolean b : usersReviewStatuses) {
+                if (!b){
+                    flag = false;
+                    break;
+                }
+            }
+            result.add(flag);
+        }
+
+        return result;
     }
 }

--- a/src/main/java/com/inconcert/domain/user/service/MyPageService.java
+++ b/src/main/java/com/inconcert/domain/user/service/MyPageService.java
@@ -2,7 +2,6 @@ package com.inconcert.domain.user.service;
 
 import com.inconcert.domain.chat.repository.ChatRoomRepository;
 import com.inconcert.domain.post.dto.PostDTO;
-import com.inconcert.domain.post.entity.Post;
 import com.inconcert.domain.post.repository.MatchRepository;
 import com.inconcert.domain.post.service.ImageService;
 import com.inconcert.domain.feedback.repository.FeedbackRepository;
@@ -13,7 +12,6 @@ import com.inconcert.domain.user.entity.User;
 import com.inconcert.domain.user.repository.MyPageRepostory;
 import com.inconcert.domain.user.repository.UserRepository;
 import com.inconcert.global.exception.ExceptionMessage;
-import com.inconcert.global.exception.PostNotFoundException;
 import com.inconcert.global.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -23,7 +21,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -95,53 +92,34 @@ public class MyPageService {
         return matchRepository.findAllByUserIdANDEndMatch(userId, pageable);
     }
 
-
+    // 해당 게시글의 평가할 유저들 불러오기
     public List<FeedbackRspDTO> getMyReviewee(Long userId, Long postId){
-        Post post = matchRepository.findById(postId)
-                .orElseThrow(() -> new PostNotFoundException(ExceptionMessage.POST_NOT_FOUND.getMessage()));
+        // 본인을 제외한 리뷰 대상 유저 불러오기
+        List<Long> matchUserIds = matchRepository.findMatchUsersByPostId(postId, userId);
 
-        List<FeedbackRspDTO> feedbackRspDTOs = userRepository.getFeedbackRspDTOByMatchUserIds(userId, post.getMatchUserIds());
-
-        feedbackRspDTOs.forEach(dto -> {
-            dto.setReviewerId(userId);
-            dto.setPostId(postId);
-        });
-
-        return feedbackRspDTOs;
+        // 리뷰 유저 대상들의 정보들 DTO에 담아서 반환
+        return userRepository.getFeedbackRspDTOByMatchUserIds(userId, postId, matchUserIds);
     }
 
     public List<Boolean> getUsersReviewStatuses(Long userId, Long postId){
-        Post post = matchRepository.findById(postId)
-                .orElseThrow(() -> new PostNotFoundException(ExceptionMessage.POST_NOT_FOUND.getMessage()));
+        // 본인을 제외한 리뷰 대상 유저 불러오기
+        List<Long> matchUserIds = matchRepository.findMatchUsersByPostId(postId, userId);
 
-        List<Long> matchUserIds = post.getMatchUserIds().stream()
-                .filter(id -> !id.equals(userId))
-                .collect(Collectors.toList());
-
+        // 이미 본인이 리뷰를 남긴 유저의 id들 불러오기
         List<Long> revieweeIds = feedbackRepository.findExistingFeedbacks(userId, matchUserIds, postId);
 
-        // admin이랑 user1을 돌아
+        // matchUserIds를 각각 돌면서 revieweeIds에 포함되었는지 확인
         return matchUserIds.stream()
-                // adminId가 이미 리뷰완료 Id에 포함돼 ?
-                .map(id -> revieweeIds.contains(id))
+                .map(revieweeIds::contains)
                 .collect(Collectors.toList());
     }
 
     public List<Boolean> isEndFeedback(Long userId, List<Long> postIds){
-        List<Boolean> result = new ArrayList<>();
-        for(Long postId : postIds){
-            List<Boolean> usersReviewStatuses = getUsersReviewStatuses(userId, postId);
-
-            boolean flag = true;
-            for (Boolean b : usersReviewStatuses) {
-                if (!b){
-                    flag = false;
-                    break;
-                }
-            }
-            result.add(flag);
-        }
-
-        return result;
+        // postIds를 각각 돌면서 getUsersReviewStatuses메소드를 호출해 전부 true인지 확인한 결과(리뷰 끝 여부)를 반환
+        return postIds.stream()
+                .map(postId -> getUsersReviewStatuses(userId, postId)
+                        .stream()
+                        .allMatch(Boolean::booleanValue))
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/inconcert/global/exception/ExceptionMessage.java
+++ b/src/main/java/com/inconcert/global/exception/ExceptionMessage.java
@@ -35,7 +35,8 @@ public enum ExceptionMessage {
     ALREADY_FULL_CHATROOM("이미 채팅방이 가득 찼습니다."),
     HOST_EXIT("호스트는 채팅방에 본인만 존재할 때 퇴장할 수 있습니다."),
     ALREADY_OUT_OF_CHATROOM("채팅방에 속해있지 않습니다."),
-    EXIST_CHAT_POST_DELETE("연결된 채팅방이 있는 경우 포스트를 삭제할 수 없습니다.");
+    EXIST_CHAT_POST_DELETE("연결된 채팅방이 있는 경우 포스트를 삭제할 수 없습니다."),
+    SELF_CHAT("본인에게는 1대1 채팅을 보낼 수 없습니다.");
 
 
 

--- a/src/main/java/com/inconcert/global/exception/SelfChatException.java
+++ b/src/main/java/com/inconcert/global/exception/SelfChatException.java
@@ -1,0 +1,7 @@
+package com.inconcert.global.exception;
+
+public class SelfChatException extends RuntimeException {
+    public SelfChatException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/inconcert/global/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/inconcert/global/handler/GlobalExceptionHandler.java
@@ -85,6 +85,13 @@ public class GlobalExceptionHandler {
         return new ResponseEntity<>(ex.getMessage(), HttpStatus.CONFLICT);
     }
 
+    // 본인에게 1대1 채팅을 시도할 때
+    @ExceptionHandler(SelfChatException.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public ResponseEntity<String> handleSelfChatException(SelfChatException ex) {
+        return new ResponseEntity<>(ex.getMessage(), HttpStatus.BAD_REQUEST);
+    }
+
     // 채팅방이 모집 완료되었을 때
     @ExceptionHandler(AlreadyFullChatRoomException.class)
     @ResponseStatus(HttpStatus.BAD_REQUEST)

--- a/src/main/resources/static/css/board/post-detail.css
+++ b/src/main/resources/static/css/board/post-detail.css
@@ -309,12 +309,20 @@ header {
 .post-info {
     display: flex;
     align-items: center;
+    justify-content: space-between;
+    font-size: 14px;
+    color: #666;
+}
+
+.post-info > div:first-child{
+    display: flex;
+    align-items: center;
     gap: 10px;
     font-size: 14px;
     color: #666;
 }
 
-.post-info > .profile-img {
+.post-info .profile-img {
     width: 40px;
     height: 40px;
     margin-top: 3px;
@@ -346,6 +354,25 @@ header {
 .date, .views {
     font-size: 12px;
     color: #999;
+}
+
+.post-info-detail{
+    align-items: center;
+}
+
+.post-info-detail > div{
+    display: flex;
+    align-items: center;
+    gap: 3px;
+}
+
+.post-info-detail > div > p{
+    margin: 0 0 5px;
+}
+
+.post-info-detail > div > p:first-child{
+    color: #00a885;
+    font-size: 14px;
 }
 
 .post-body {

--- a/src/main/resources/static/css/user/match-list.css
+++ b/src/main/resources/static/css/user/match-list.css
@@ -8,11 +8,6 @@ html {
     flex-shrink: 0;
 }
 
-p{
-    margin: 5px;
-    padding: 0;
-}
-
 body {
     display: flex;
     flex-direction: column;
@@ -22,8 +17,8 @@ body {
 
 .container {
     flex: 1;
-    min-width: calc(100% - 300px);
-    max-width: calc(100% - 300px);
+    width: 80%;
+    max-width: 80%;
     margin: 0 auto;
 }
 
@@ -33,14 +28,14 @@ body {
     justify-content: center;
     align-items: center;
     margin: 0 auto;
-    min-width: 1300px;
-    max-width: 1300px;
+    width: 100%;
+    max-width: 100%;
 }
 
 header {
     display: flex;
-    min-width: 1280px;
-    max-width: 1280px;
+    width: 100%;
+    max-width: 100%;
     justify-content: space-between;
     align-items: center;
     padding: 10px;
@@ -218,14 +213,12 @@ header {
     margin: 3px 0;
 }
 
-.review-block{
-    margin-top: 40px;
-}
+/* */
 
 .title-container{
-    min-width: 1300px;
-    max-width: 1300px;
-    margin: 0 auto 50px;
+    width: 100%;
+    max-width: 100%;
+    margin: 0 auto 20px;
 }
 
 .title-container h1{
@@ -237,45 +230,95 @@ header {
     color: #6f6f6f;
 }
 
+.container > section{
+    width: 100%;
+    max-width: 100%;
+    margin: 0 auto
+}
+
+.nav-tabs{
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0;
+    gap: 150px;
+    margin-bottom: 100px;
+}
+
+.nav-tabs > li{
+    list-style-type: none;
+}
+
+.nav-tabs > li > a{
+    text-decoration: none;
+    color: #6f6f6f;
+    font-size: 20px;
+    font-weight: bold;
+}
+
+.nav-tabs > li > a:hover{
+    color: #00a885;
+    cursor: pointer;
+}
+
+.nav-tabs li.active a {
+    color: #00a885;
+}
+
 .post-header {
     display: flex;
     justify-content: space-between;
-    padding: 10px;
     font-weight: bold;
-    margin: 0 auto;
-    gap: 10px;
-    min-width: 1280px;
-    max-width: 1280px;
+    margin: 0 auto 10px;
+    min-width: 100%;
+    max-width: 100%;
 }
 
 .post-header span {
     text-align: center;
 }
 
-.header-title {
+.header-title{
     flex: 5; /* 제목이 50% 차지 */
 }
 
 .header-author,
 .header-date,
-.header-views,
-.header-likes {
-    flex: 1; /* 나머지 항목이 각각 12.5%씩 차지 */
+.header-match-count,
+.header-status,
+.header-review{
+    flex: 1;
 }
 
 .post-list {
-    border-top: 1px solid #ddd;
     margin: 0 auto;
-    min-width: 1300px;
-    max-width: 1300px;
+    gap: 10px;
+    min-width: 100%;
+    max-width: 100%;
 }
 
 .post {
     display: flex;
-    padding: 10px;
-    border-bottom: 1px solid #ddd;
+    padding: 10px 0;
+    border-top: 1px solid #ccc;
     background-color: #ffffff;
     transition: background-color 0.3s ease;
+}
+
+.post-list > .post:last-child{
+    border-bottom: 1px solid #ccc;
+}
+
+.post-content {
+    display: flex;
+    align-items: center;
+    flex-grow: 1;
+}
+
+.post-left{
+    display: flex;
+    align-items: center;
+    flex: 5;
 }
 
 .post-thumbnail {
@@ -289,17 +332,8 @@ header {
     object-fit: cover;
 }
 
-.post-content {
-    display: flex;
-    flex-grow: 1;
-    align-items: center;
-}
-
 .post-title {
     flex: 5; /* 제목이 50% 차지 */
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
     display: flex;
     align-items: center;
     gap: 5px;
@@ -317,44 +351,54 @@ header {
     text-decoration: underline;
 }
 
-.post-title > a > span:nth-child(2){
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 410px;
-    display: block;
-}
-
-.comment-count{
-    color: red;
-    padding: 0;
-}
-
-.post-title > div{
-    border: none;
-    border-radius: 50%;
-    background-color: red;
-    color: white;
-    width: 18px;
-    height: 18px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-}
-
-.post-meta {
+.post-right {
     display: flex;
     flex: 5;
     justify-content: space-between;
     align-items: center;
-    margin-left: 45px;
 }
 
-.post-meta span {
+.post-right > span,
+.post-right > a,
+.post-right > div{
     flex: 1;
     text-align: center;
+}
+
+.author, .date, .match-count{
     color: #6f6f6f;
-    white-space: nowrap;
+}
+
+div.status > span,
+.need-feedback,
+.matching{
+    border-radius: 15px;
+    text-decoration: none;
+    background-color: #00a885;
+    color: white;
+    font-weight: bolder;
+    padding: 7px;
+    text-decoration: none;
+}
+
+div.review > a{
+    text-decoration: none;
+}
+
+.need-feedback:hover {
+    cursor: pointer;
+    color: #00a885;
+    border: 1px solid #00a885;
+    background-color: white;
+}
+
+.complete-feedback{
+    border-radius: 15px;
+    text-decoration: none;
+    background-color: #6f6f6f;
+    color: white;
+    font-weight: bolder;
+    padding: 7px;
 }
 
 .pagination > ul{

--- a/src/main/resources/static/css/user/match-list.css
+++ b/src/main/resources/static/css/user/match-list.css
@@ -369,7 +369,7 @@ header {
     color: #6f6f6f;
 }
 
-div.status > span,
+div.status > .status-ing,
 .need-feedback,
 .matching{
     border-radius: 15px;
@@ -378,7 +378,15 @@ div.status > span,
     color: white;
     font-weight: bolder;
     padding: 7px;
+}
+
+div.status > .status-end{
+    border-radius: 15px;
     text-decoration: none;
+    background-color: red;
+    color: white;
+    font-weight: bolder;
+    padding: 7px;
 }
 
 div.review > a{

--- a/src/main/resources/static/css/user/review-list.css
+++ b/src/main/resources/static/css/user/review-list.css
@@ -8,11 +8,6 @@ html {
     flex-shrink: 0;
 }
 
-p{
-    margin: 5px;
-    padding: 0;
-}
-
 body {
     display: flex;
     flex-direction: column;
@@ -22,8 +17,8 @@ body {
 
 .container {
     flex: 1;
-    min-width: calc(100% - 300px);
-    max-width: calc(100% - 300px);
+    width: 80%;
+    max-width: 80%;
     margin: 0 auto;
 }
 
@@ -33,17 +28,17 @@ body {
     justify-content: center;
     align-items: center;
     margin: 0 auto;
-    min-width: 1300px;
-    max-width: 1300px;
+    width: 100%;
+    max-width: 100%;
 }
 
 header {
     display: flex;
-    min-width: 1280px;
-    max-width: 1280px;
+    width: 100%;
+    max-width: 100%;
     justify-content: space-between;
     align-items: center;
-    padding: 10px;
+    padding: 10px 0;
     margin: 0 auto;
 }
 
@@ -218,14 +213,12 @@ header {
     margin: 3px 0;
 }
 
-.review-block{
-    margin-top: 40px;
-}
+/* */
 
 .title-container{
-    min-width: 1300px;
-    max-width: 1300px;
-    margin: 0 auto 50px;
+    width: 60%;
+    max-width: 60%;
+    margin: 0 auto 20px;
 }
 
 .title-container h1{
@@ -237,154 +230,168 @@ header {
     color: #6f6f6f;
 }
 
+.review-container{
+    width: 60%;
+    max-width: 60%;
+    margin: 0 auto 50px;
+}
+
 .post-header {
     display: flex;
     justify-content: space-between;
-    padding: 10px;
     font-weight: bold;
-    margin: 0 auto;
-    gap: 10px;
-    min-width: 1280px;
-    max-width: 1280px;
+    margin: 0 auto 10px;
+    width: 100%;
+    max-width: 100%;
 }
 
 .post-header span {
     text-align: center;
 }
 
-.header-title {
-    flex: 5; /* 제목이 50% 차지 */
+.header-image,
+.header-nickname,
+.header-birth,
+.header-mbti,
+.header-gender,
+.header-review{
+    flex: 2;
 }
 
-.header-author,
-.header-date,
-.header-views,
-.header-likes {
-    flex: 1; /* 나머지 항목이 각각 12.5%씩 차지 */
-}
-
-.post-list {
-    border-top: 1px solid #ddd;
-    margin: 0 auto;
-    min-width: 1300px;
-    max-width: 1300px;
-}
-
-.post {
+.review-container > div:nth-child(n+2){
     display: flex;
-    padding: 10px;
-    border-bottom: 1px solid #ddd;
-    background-color: #ffffff;
-    transition: background-color 0.3s ease;
+    align-items: center;
+    text-align: center;
 }
 
-.post-thumbnail {
-    flex-shrink: 0;
-    margin-right: 15px;
+.reviewee-img{
+    display: flex;
+    align-items: center;
+    justify-content: center;
 }
 
-.post-thumbnail img {
+.reviewee-img img {
     width: 50px;
     height: 50px;
+    border-radius: 50%;
     object-fit: cover;
 }
 
-.post-content {
-    display: flex;
-    flex-grow: 1;
-    align-items: center;
+.reviewee-img,
+.reviewee-nickname,
+.reviewee-birth,
+.reviewee-mbti,
+.reviewee-gender,
+.reviewee-review{
+    flex: 2;
 }
 
-.post-title {
-    flex: 5; /* 제목이 50% 차지 */
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    display: flex;
-    align-items: center;
-    gap: 5px;
-}
-
-.post-title > a{
-    color: black;
-    text-decoration: none;
-    display: flex;
-    align-items: center;
-    gap: 3px;
-}
-
-.post-title > a:hover{
-    text-decoration: underline;
-}
-
-.post-title > a > span:nth-child(2){
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    max-width: 410px;
-    display: block;
-}
-
-.comment-count{
-    color: red;
-    padding: 0;
-}
-
-.post-title > div{
+.openReviewPopupBtn{
     border: none;
-    border-radius: 50%;
-    background-color: red;
+    border-radius: 15px;
+    padding: 7px;
+    background-color: #00a885;
     color: white;
-    width: 18px;
-    height: 18px;
-    display: flex;
-    justify-content: center;
-    align-items: center;
 }
 
-.post-meta {
+.openReviewPopupBtn:hover{
+    cursor: pointer;
+    color: #00a885;
+    background-color: white;
+    border: 1px solid #00a885;
+}
+
+.disabledPopupBtn{
+    border: none;
+    border-radius: 15px;
+    padding: 7px;
+    background-color: #6f6f6f;
+    color: white;
+}
+
+
+
+
+/* 팝업 배경 */
+.popup {
+    position: fixed;
+    z-index: 1000;
+    left: 0;
+    top: 0;
+    width: 100%;
+    height: 100%;
+    background-color: rgba(0, 0, 0, 0.5);
+}
+
+/* 팝업 내용 */
+.popup-content {
+    position: absolute;
+    background-color: #fff;
+    padding: 30px;
+    border-radius: 10px;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+    width: 400px;
+    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.3);
+}
+
+/* 닫기 버튼 */
+.close {
+    position: absolute;
+    right: 15px;
+    top: 15px;
+    font-size: 20px;
+    cursor: pointer;
+}
+
+/* 제목 스타일 */
+.popup-content h2 {
+    margin-top: 0;
+    color: #333;
+}
+
+/* 평점 버튼 스타일 */
+.rating-buttons {
     display: flex;
-    flex: 5;
     justify-content: space-between;
-    align-items: center;
-    margin-left: 45px;
+    margin: 20px 0;
 }
 
-.post-meta span {
-    flex: 1;
+.rating-buttons input[type="radio"] {
+    display: none;
+}
+
+.rating-buttons label {
+    display: inline-block;
+    width: 30px;
+    height: 30px;
+    line-height: 30px;
     text-align: center;
-    color: #6f6f6f;
-    white-space: nowrap;
+    border-radius: 50%;
+    background-color: #ddd;
+    cursor: pointer;
+    transition: background-color 0.3s;
 }
 
-.pagination > ul{
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 15px;
+.rating-buttons input[type="radio"]:checked + label {
+    background-color: #00a885;
+    color: white;
 }
 
-.pagination > ul > li{
-    list-style-type: none;
+/* 제출 버튼 스타일 */
+.submit-btn {
+    background-color: #00a885;
+    color: white;
+    padding: 10px 20px;
+    border: none;
+    border-radius: 5px;
+    cursor: pointer;
+    font-size: 16px;
+    width: 100%;
+    margin-top: 20px;
 }
 
-.pagination > ul > li a{
-    color: #6f6f6f;
-    text-decoration: none;
-    align-items: center;
-}
-
-.pagination > ul > li.active a {
-    color: #0BA885;
-    font-weight: bold;
-}
-
-.pagination > ul > li.disabled a {
-    color: #ccc;
-    pointer-events: none;
-    cursor: default;
-}
-
-.pagination > ul > li.disabled span {
-    color: #ccc;
+.submit-btn:hover {
+    background-color: #009878;
 }

--- a/src/main/resources/static/css/user/review-list.css
+++ b/src/main/resources/static/css/user/review-list.css
@@ -218,7 +218,7 @@ header {
 .title-container{
     width: 60%;
     max-width: 60%;
-    margin: 0 auto 20px;
+    margin: 0 auto;
 }
 
 .title-container h1{
@@ -228,6 +228,27 @@ header {
 
 .title-container > p{
     color: #6f6f6f;
+}
+
+.button-container{
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    margin: 0 auto 50px;
+    width: 60%;
+    max-width: 60%;
+}
+
+.button-container > a{
+    text-decoration: none;
+    color: #00a885;
+    font-size: 20px;
+    font-weight: bolder;
+}
+
+.button-container > a:hover{
+    color: black;
+    cursor: pointer;
 }
 
 .review-container{

--- a/src/main/resources/static/js/board/post-detail.js
+++ b/src/main/resources/static/js/board/post-detail.js
@@ -108,8 +108,11 @@ function validateSearch() {
 }
 
 function matchComplete() {
-    if(confirm("현재 채팅방 인원으로 동행 정보를 저장합니다.")) {
-        alert("동행이 완료되었습니다.")
+    if (!confirm("현재 채팅방 인원으로 동행 정보를 저장합니다.")) {
+        return false;
+    } else{
+        alert("동행이 완료되었습니다.");
+        return true;
     }
 }
 

--- a/src/main/resources/static/js/board/post-detail.js
+++ b/src/main/resources/static/js/board/post-detail.js
@@ -107,6 +107,12 @@ function validateSearch() {
     return true;
 }
 
+function matchComplete() {
+    if(confirm("현재 채팅방 인원으로 동행 정보를 저장합니다.")) {
+        alert("동행이 완료되었습니다.")
+    }
+}
+
 // 동행 요청
 function requestJoinChatRoom(button) {
     const chatRoomId = button.getAttribute("data-chat-room-id");
@@ -149,6 +155,8 @@ function requestOneToOneChat(button) {
         .then(response => {
             if (response.status === 409) {
                 throw new Error('이미 해당 유저와의 채팅방이 존재합니다.');
+            } else if(response.status === 400){
+                throw new Error('본인에게는 1대1 채팅을 보낼 수 없습니다.');
             } else if (!response.ok) {
                 throw new Error('알 수 없는 오류가 발생했습니다.');
             }

--- a/src/main/resources/templates/board/post-detail.html
+++ b/src/main/resources/templates/board/post-detail.html
@@ -87,8 +87,8 @@
                         <form th:action="@{|/${categoryTitle}/${postCategoryTitle}/${post.id}/complete|}" method="post"
                               th:if="${user.isPresent() &&
                                     post.user.username == user.get().username &&
-                                    #temporals.format(post.endDate, 'yyyy-MM-dd') < #temporals.format(#temporals.createNow(), 'yyyy-MM-dd') && !post.end}">
-                            <button class="chat-button" type="submit" onclick="matchComplete()"> 동행 완료 </button>
+                                    #temporals.format(post.endDate, 'yyyy-MM-dd') <= #temporals.format(#temporals.createNow(), 'yyyy-MM-dd') && !post.end}">
+                            <button class="chat-button" type="submit" onclick="return matchComplete()"> 동행 완료 </button>
                         </form>
 
                         <input type="hidden" id="chatRoomId" th:value="${post.chatRoomId}">
@@ -139,7 +139,7 @@
                onclick="toggleLike(this)"></i>
             <span id="like-count" th:text="${post.likeCount}"></span>
             <span th:text="'댓글 '+ ${post.commentCount}"></span>
-            <a id="kakaotalk-sharing-btn" href="javascript:;">
+            <a id="kakaotalk-sharing-btn" href="javascript:">
                 <img src="/images/sns/kakao.png"
                      alt="카카오톡 공유 보내기 버튼" />
             </a>

--- a/src/main/resources/templates/board/post-detail.html
+++ b/src/main/resources/templates/board/post-detail.html
@@ -57,39 +57,62 @@
         </div>
 
         <div class="post-info">
-            <img id="profileImage" th:src="${post.user.profileImage}" class="profile-img" alt="프로필 이미지">
             <div>
-                <div class="author-row">
-                    <span class="author" th:text="${post.nickname}"></span>
-                    <button class="chat-button" th:if="${user.isPresent() && post.user.username != user.get().username}" th:data-receiver-id="${post.user.id}" onclick="requestOneToOneChat(this)">1:1 채팅</button>
-                    <button class="chat-button" th:if="${categoryTitle == 'match' && user.isPresent() && post.user.username != user.get().username}" th:data-chat-room-id="${post.chatRoomId}" onclick="requestJoinChatRoom(this)">동행 요청</button>
-                    <button class="chat-button"
-                            th:if="${user?.isPresent()} and ${post?.nickname == user.get().nickname}"
-                            th:href="@{|/${categoryTitle}/${postCategoryTitle}/${post.id}/edit|}"
-                            th:attr="data-has-chat-room=${hasChatRoom}"
-                            onclick="location.href=this.getAttribute('href');">
-                        수정
-                    </button>
-
-                    <form th:action="@{|/${categoryTitle}/${postCategoryTitle}/${post.id}/delete|}" method="post"
-                          th:if="${user?.isPresent()} and ${post?.nickname == user.get().nickname}">
-                        <button type="submit" class="chat-button" id="delete-button"
+                <img id="profileImage" th:src="${post.user.profileImage}" class="profile-img" alt="프로필 이미지">
+                <div>
+                    <div class="author-row">
+                        <span class="author" th:text="${post.nickname}"></span>
+                        <button class="chat-button"
+                                th:if="${user.isPresent() && post.user.username != user.get().username}"
+                                th:data-receiver-id="${post.user.id}" onclick="requestOneToOneChat(this)">1:1 채팅</button>
+                        <button class="chat-button"
+                                th:if="${categoryTitle == 'match' && user.isPresent() && post.user.username != user.get().username && !post.end}"
+                                th:data-chat-room-id="${post.chatRoomId}" onclick="requestJoinChatRoom(this)">동행 요청</button>
+                        <button class="chat-button"
+                                th:if="${user?.isPresent()} and ${post?.nickname == user.get().nickname && !post.end}"
+                                th:href="@{|/${categoryTitle}/${postCategoryTitle}/${post.id}/edit|}"
                                 th:attr="data-has-chat-room=${hasChatRoom}"
-                                onclick="return confirmDelete(this)">
-                            삭제
+                                onclick="location.href=this.getAttribute('href');">
+                            수정
                         </button>
-                    </form>
-                    <input type="hidden" id="chatRoomId" th:value="${post.chatRoomId}">
-                    <div th:if="${errorMessage}" id="errorMessage" th:text="${errorMessage}" style="display: none;"></div>
-                    <a th:href="@{|/${categoryTitle}/${postCategoryTitle}/${post.id}/report|}"
-                       th:if="${user?.isPresent() && post?.nickname != user.get().nickname}"
-                       class="report-button">
-                        신고
-                    </a>
+                        <form th:action="@{|/${categoryTitle}/${postCategoryTitle}/${post.id}/delete|}" method="post"
+                              th:if="${user?.isPresent()} and ${post?.nickname == user.get().nickname && !post.end}">
+                            <button type="submit" class="chat-button" id="delete-button"
+                                    th:attr="data-has-chat-room=${hasChatRoom}"
+                                    onclick="return confirmDelete(this)">
+                                삭제
+                            </button>
+                        </form>
+
+                        <form th:action="@{|/${categoryTitle}/${postCategoryTitle}/${post.id}/complete|}" method="post"
+                              th:if="${user.isPresent() &&
+                                    post.user.username == user.get().username &&
+                                    #temporals.format(post.endDate, 'yyyy-MM-dd') < #temporals.format(#temporals.createNow(), 'yyyy-MM-dd') && !post.end}">
+                            <button class="chat-button" type="submit" onclick="matchComplete()"> 동행 완료 </button>
+                        </form>
+
+                        <input type="hidden" id="chatRoomId" th:value="${post.chatRoomId}">
+                        <div th:if="${errorMessage}" id="errorMessage" th:text="${errorMessage}" style="display: none;"></div>
+                        <a th:href="@{|/${categoryTitle}/${postCategoryTitle}/${post.id}/report|}"
+                           th:if="${user?.isPresent() && post?.nickname != user.get().nickname}"
+                           class="report-button">
+                            신고
+                        </a>
+                    </div>
+                    <div class="date-row">
+                        <span class="date" th:text="${#temporals.format(post.createdAt, 'yyyy-MM-dd HH:mm')}"></span>
+                        <span class="views" th:text="${post.viewCount}"></span>
+                    </div>
                 </div>
-                <div class="date-row">
-                    <span class="date" th:text="${#temporals.format(post.createdAt, 'yyyy-MM-dd HH:mm')}"></span>
-                    <span class="views" th:text="${post.viewCount}"></span>
+            </div>
+            <div class="post-info-detail" th:if="${categoryTitle == 'match'}">
+                <div>
+                    <p>마감 날짜:</p>
+                    <p th:text="${#temporals.format(post.endDate, 'yyyy-MM-dd')}"></p>
+                </div>
+                <div>
+                    <p>현재 인원: </p>
+                    <p th:text="${post.chatRoomUserSize + '/' + post.matchCount}"></p>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/user/match-list.html
+++ b/src/main/resources/templates/user/match-list.html
@@ -1,0 +1,192 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>알림 설정</title>
+    <link rel="stylesheet" href="/css/user/match-list.css">
+</head>
+<body>
+<div class="container">
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="title-container">
+        <h1>내 동행 목록</h1>
+        <p th:text="${activeTab == 'present' ? matchRspDTOs.getTotalElements() + '개의 동행을 함께 하고 있습니다 !' :  '지금까지 총 ' + matchRspDTOs.getTotalElements() + '번의 동행을 완료했습니다!' }"> </p>
+    </div>
+
+    <section>
+        <nav>
+            <ul class="nav-tabs">
+                <li th:classappend="${activeTab} == 'present' ? 'active'">
+                    <a th:href="@{'/mypage/match/' + ${user.id} + '/present'}">동행중</a>
+                </li>
+                <li th:classappend="${activeTab} == 'complete' ? 'active'">
+                    <a th:href="@{'/mypage/match/' + ${user.id} + '/complete'}">동행 완료</a>
+                </li>
+            </ul>
+        </nav>
+
+        <div th:if="${activeTab == 'present'}">
+            <div class="post-header" th:if="${matchRspDTOs.getTotalElements() > 0}">
+                <span class="header-title">제목</span>
+                <span class="header-author">작성자</span>
+                <span class="header-date">마감 날짜</span>
+                <span class="header-match-count">인원 수</span>
+                <span class="header-status">모집 상태</span>
+                <span class="header-review">상호 평가</span>
+
+            </div>
+
+            <div class="post-list">
+                <div class="post" th:each="matchRspDTO : ${matchRspDTOs.content}">
+                    <div class="post-content">
+                        <div class="post-left">
+                            <div class="post-thumbnail" th:if="${matchRspDTO.thumbnailUrl != null}">
+                                <img th:src="@{${matchRspDTO.thumbnailUrl}}">
+                            </div>
+                            <div class="post-thumbnail" th:if="${matchRspDTO.thumbnailUrl == null}">
+                                <img src="/images/logo.png" alt="No Posts"/>
+                            </div>
+                            <div class="post-title">
+                                <a th:href="@{'/' + ${matchRspDTO.categoryTitle} + '/' + ${matchRspDTO.postCategoryTitle} + '/' + ${matchRspDTO.postId}}">
+                                    <span th:switch="${matchRspDTO.postCategoryTitle}">
+                                        <span th:case="'musical'">[뮤지컬]</span>
+                                        <span th:case="'concert'">[콘서트]</span>
+                                        <span th:case="'theater'">[연극]</span>
+                                        <span th:case="'etc'">[기타]</span>
+                                    </span>
+                                    <span th:text="${#strings.length(matchRspDTO.title) > 23 ? #strings.substring(matchRspDTO.title, 0, 23) + '...' : matchRspDTO.title}">Post Title</span>
+                                </a>
+                            </div>
+                        </div>
+
+                        <div class="post-right">
+                            <span class="author" th:text="${matchRspDTO.hostNickname}"></span>
+                            <span class="date" th:text="${#temporals.format(matchRspDTO.endDate, 'yyyy-MM-dd')}"></span>
+                            <span class="match-count" th:text="${matchRspDTO.chatRoomUserSize + '/' + matchRspDTO.matchCount}"></span>
+                            <div class="status">
+                                <span th:text="${matchRspDTO.end ? '모집 종료' : '모집중'}"></span>
+                            </div>
+                            <div class="review">
+                                <span class="matching">동행중</span>
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div th:if="${totalPages > 0}" class="pagination">
+                <ul>
+                    <!-- 이전 페이지 -->
+                    <li th:classappend="${currentPage == 0} ? 'disabled'">
+                        <a th:if="${currentPage > 0}"
+                           th:href="@{|/mypage/${user.id}/present?page=${currentPage - 1}&size=${matchRspDTOs.size}|}">
+                            이전</a>
+                        <span th:if="${currentPage == 0}">이전</span>
+                    </li>
+
+                    <!-- 페이지 번호 -->
+                    <li th:each="i : ${#numbers.sequence(0, totalPages - 1)}"
+                        th:if="${i >= (currentPage / 10) * 10 && i < ((currentPage / 10) + 1) * 10}"
+                        th:classappend="${i == currentPage} ? 'active'">
+                        <a th:href="@{|/mypage/${user.id}/present?page=${i}&size=${matchRspDTOs.size}|}"
+                           th:text="${i + 1}">1</a>
+                    </li>
+
+                    <!-- 다음 페이지 -->
+                    <li th:classappend="${currentPage + 1 >= totalPages} ? 'disabled'">
+                        <a th:if="${currentPage + 1 < totalPages}"
+                           th:href="@{|/mypage/${user.id}/present?page=${currentPage + 1}&size=${matchRspDTOs.size}|}">
+                            다음</a>
+                        <span th:if="${currentPage + 1 >= totalPages}">다음</span>
+                    </li>
+                </ul>
+            </div>
+        </div>
+
+        <div th:if="${activeTab == 'complete'}">
+            <div class="post-header" th:if="${matchRspDTOs.getTotalElements() > 0}">
+                <span class="header-title">제목</span>
+                <span class="header-author">작성자</span>
+                <span class="header-date">마감 날짜</span>
+                <span class="header-match-count">인원 수</span>
+                <span class="header-status">모집 상태</span>
+                <span class="header-review">상호 평가</span>
+            </div>
+
+            <div class="post-list" th:each="matchRspDTO, iterStat : ${matchRspDTOs.content}">
+                <div class="post">
+                    <div class="post-content">
+                        <div class="post-left">
+                            <div class="post-thumbnail" th:if="${matchRspDTO.thumbnailUrl != null}">
+                                <img th:src="@{${matchRspDTO.thumbnailUrl}}">
+                            </div>
+                            <div class="post-thumbnail" th:if="${matchRspDTO.thumbnailUrl == null}">
+                                <img src="/images/logo.png" alt="No Posts"/>
+                            </div>
+                            <div class="post-title">
+                                <a th:href="@{'/' + ${matchRspDTO.categoryTitle} + '/' + ${matchRspDTO.postCategoryTitle} + '/' + ${matchRspDTO.postId}}">
+                                    <span th:switch="${matchRspDTO.postCategoryTitle}">
+                                        <span th:case="'musical'">[뮤지컬]</span>
+                                        <span th:case="'concert'">[콘서트]</span>
+                                        <span th:case="'theater'">[연극]</span>
+                                        <span th:case="'etc'">[기타]</span>
+                                    </span>
+                                    <span th:text="${#strings.length(matchRspDTO.title) > 23 ? #strings.substring(matchRspDTO.title, 0, 23) + '...' : matchRspDTO.title}">Post Title</span>
+                                </a>
+                            </div>
+                        </div>
+
+                        <div class="post-right">
+                            <span class="author" th:text="${matchRspDTO.hostNickname}"></span>
+                            <span class="date" th:text="${#temporals.format(matchRspDTO.endDate, 'yyyy-MM-dd')}"></span>
+                            <span class="match-count" th:text="${matchRspDTO.chatRoomUserSize + '/' + matchRspDTO.matchCount}"></span>
+                            <div class="status">
+                                <span th:text="${matchRspDTO.end ? '모집 종료' : '모집중'}"></span>
+                            </div>
+                            <div class="review">
+                                <a th:href="${'/mypage/match/' + user.id + '/complete/' + matchRspDTO.postId}">
+                                    <span class="need-feedback" th:if="${!isEndFeedback.get(iterStat.index)}">평가하기</span>
+                                </a>
+                                <span class="complete-feedback" th:if="${isEndFeedback.get(iterStat.index)}">평가완료</span>
+
+                            </div>
+
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div th:if="${totalPages > 0}" class="pagination">
+                <ul>
+                    <!-- 이전 페이지 -->
+                    <li th:classappend="${currentPage == 0} ? 'disabled'">
+                        <a th:if="${currentPage > 0}"
+                           th:href="@{|/mypage/${user.id}/complete?page=${currentPage - 1}&size=${matchRspDTOs.size}|}">
+                            이전</a>
+                        <span th:if="${currentPage == 0}">이전</span>
+                    </li>
+
+                    <!-- 페이지 번호 -->
+                    <li th:each="i : ${#numbers.sequence(0, totalPages - 1)}"
+                        th:if="${i >= (currentPage / 10) * 10 && i < ((currentPage / 10) + 1) * 10}"
+                        th:classappend="${i == currentPage} ? 'active'">
+                        <a th:href="@{|/mypage/${user.id}/complete?page=${i}&size=${matchRspDTOs.size}|}"
+                           th:text="${i + 1}">1</a>
+                    </li>
+
+                    <!-- 다음 페이지 -->
+                    <li th:classappend="${currentPage + 1 >= totalPages} ? 'disabled'">
+                        <a th:if="${currentPage + 1 < totalPages}"
+                           th:href="@{|/mypage/${user.id}/complete?page=${currentPage + 1}&size=${matchRspDTOs.size}|}">
+                            다음</a>
+                        <span th:if="${currentPage + 1 >= totalPages}">다음</span>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </section>
+</div>
+
+<div th:replace="~{fragments/footer :: footer}"></div>
+</body>
+</html>

--- a/src/main/resources/templates/user/match-list.html
+++ b/src/main/resources/templates/user/match-list.html
@@ -65,7 +65,7 @@
                             <span class="date" th:text="${#temporals.format(matchRspDTO.endDate, 'yyyy-MM-dd')}"></span>
                             <span class="match-count" th:text="${matchRspDTO.chatRoomUserSize + '/' + matchRspDTO.matchCount}"></span>
                             <div class="status">
-                                <span th:text="${matchRspDTO.end ? '모집 종료' : '모집중'}"></span>
+                                <span class="status-ing">모집중</span>
                             </div>
                             <div class="review">
                                 <span class="matching">동행중</span>
@@ -80,7 +80,7 @@
                     <!-- 이전 페이지 -->
                     <li th:classappend="${currentPage == 0} ? 'disabled'">
                         <a th:if="${currentPage > 0}"
-                           th:href="@{|/mypage/${user.id}/present?page=${currentPage - 1}&size=${matchRspDTOs.size}|}">
+                           th:href="@{|/mypage/match/${user.id}/present?page=${currentPage - 1}&size=${matchRspDTOs.size}|}">
                             이전</a>
                         <span th:if="${currentPage == 0}">이전</span>
                     </li>
@@ -89,14 +89,14 @@
                     <li th:each="i : ${#numbers.sequence(0, totalPages - 1)}"
                         th:if="${i >= (currentPage / 10) * 10 && i < ((currentPage / 10) + 1) * 10}"
                         th:classappend="${i == currentPage} ? 'active'">
-                        <a th:href="@{|/mypage/${user.id}/present?page=${i}&size=${matchRspDTOs.size}|}"
+                        <a th:href="@{|/mypage/match/${user.id}/present?page=${i}&size=${matchRspDTOs.size}|}"
                            th:text="${i + 1}">1</a>
                     </li>
 
                     <!-- 다음 페이지 -->
                     <li th:classappend="${currentPage + 1 >= totalPages} ? 'disabled'">
                         <a th:if="${currentPage + 1 < totalPages}"
-                           th:href="@{|/mypage/${user.id}/present?page=${currentPage + 1}&size=${matchRspDTOs.size}|}">
+                           th:href="@{|/mypage/match/${user.id}/present?page=${currentPage + 1}&size=${matchRspDTOs.size}|}">
                             다음</a>
                         <span th:if="${currentPage + 1 >= totalPages}">다음</span>
                     </li>
@@ -142,7 +142,7 @@
                             <span class="date" th:text="${#temporals.format(matchRspDTO.endDate, 'yyyy-MM-dd')}"></span>
                             <span class="match-count" th:text="${matchRspDTO.chatRoomUserSize + '/' + matchRspDTO.matchCount}"></span>
                             <div class="status">
-                                <span th:text="${matchRspDTO.end ? '모집 종료' : '모집중'}"></span>
+                                <span class="status-end"> 모집 종료 </span>
                             </div>
                             <div class="review">
                                 <a th:href="${'/mypage/match/' + user.id + '/complete/' + matchRspDTO.postId}">
@@ -161,7 +161,7 @@
                     <!-- 이전 페이지 -->
                     <li th:classappend="${currentPage == 0} ? 'disabled'">
                         <a th:if="${currentPage > 0}"
-                           th:href="@{|/mypage/${user.id}/complete?page=${currentPage - 1}&size=${matchRspDTOs.size}|}">
+                           th:href="@{|/mypage/match/${user.id}/complete?page=${currentPage - 1}&size=${matchRspDTOs.size}|}">
                             이전</a>
                         <span th:if="${currentPage == 0}">이전</span>
                     </li>
@@ -170,14 +170,14 @@
                     <li th:each="i : ${#numbers.sequence(0, totalPages - 1)}"
                         th:if="${i >= (currentPage / 10) * 10 && i < ((currentPage / 10) + 1) * 10}"
                         th:classappend="${i == currentPage} ? 'active'">
-                        <a th:href="@{|/mypage/${user.id}/complete?page=${i}&size=${matchRspDTOs.size}|}"
+                        <a th:href="@{|/mypage/match/${user.id}/complete?page=${i}&size=${matchRspDTOs.size}|}"
                            th:text="${i + 1}">1</a>
                     </li>
 
                     <!-- 다음 페이지 -->
                     <li th:classappend="${currentPage + 1 >= totalPages} ? 'disabled'">
                         <a th:if="${currentPage + 1 < totalPages}"
-                           th:href="@{|/mypage/${user.id}/complete?page=${currentPage + 1}&size=${matchRspDTOs.size}|}">
+                           th:href="@{|/mypage/match/${user.id}/complete?page=${currentPage + 1}&size=${matchRspDTOs.size}|}">
                             다음</a>
                         <span th:if="${currentPage + 1 >= totalPages}">다음</span>
                     </li>

--- a/src/main/resources/templates/user/match-list.html
+++ b/src/main/resources/templates/user/match-list.html
@@ -2,7 +2,7 @@
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>알림 설정</title>
+    <title>내 동행 목록</title>
     <link rel="stylesheet" href="/css/user/match-list.css">
 </head>
 <body>

--- a/src/main/resources/templates/user/mypage-detail.html
+++ b/src/main/resources/templates/user/mypage-detail.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <title>메인 화면</title>
-    <link rel="stylesheet" href="/css/search-result.css">
+    <link rel="stylesheet" href="/css/user/mypage-detail.css">
     <script>
         function validateSearch() {
             let keyword = document.getElementById("search-input").value.trim();

--- a/src/main/resources/templates/user/mypage.html
+++ b/src/main/resources/templates/user/mypage.html
@@ -49,7 +49,7 @@
                     <a class="link-btn" th:href="@{'/mypage/like/' + ${user.id}}">
                         <h3> 좋아요한 글 보기 </h3>
                     </a>
-                    <a class="link-btn" th:href="@{/mypage/with}">
+                    <a class="link-btn" th:href="@{'/mypage/match/' + ${user.id} + '/present'}">
                         <h3> 내 동행 목록 </h3>
                     </a>
                 </div>

--- a/src/main/resources/templates/user/review-list.html
+++ b/src/main/resources/templates/user/review-list.html
@@ -42,10 +42,6 @@
                 <input th:id="'reviewerId' + ${iterStat.index}" type="hidden" th:value="${reviewee.reviewerId}">
                 <input th:id="'revieweeId' + ${iterStat.index}" type="hidden" th:value="${reviewee.revieweeId}">
                 <input th:id="'postId' + ${iterStat.index}" type="hidden" th:value="${reviewee.postId}">
-
-<!--                <input th:data-reviewer-id="${reviewee.reviewerId}" type="hidden">-->
-<!--                <input th:data-post-id="${reviewee.postId}" type="hidden">-->
-<!--                <input th:data-reviewee-id="${reviewee.revieweeId}" type="hidden">-->
             </div>
 
             <div class="popup" style="display: none;" th:id="'reviewPopup' + ${iterStat.index}">
@@ -89,18 +85,18 @@
 
             popup.querySelector('.reviewForm').addEventListener('submit', function(event) {
                 event.preventDefault();
-                const rating = this.querySelector(`input[name="rating${index}"]:checked`).value;
+                const rating = this.querySelector(`input[name="rating${index}"]:checked`);
+
                 if (!rating) {
                     alert("평가 점수를 선택해주세요.");
                     return;
                 }
-                console.log(rating);
 
                 let reviewerId = document.getElementById('reviewerId' + index).value;
                 let revieweeId = document.getElementById('revieweeId' + index).value;
                 let postId = document.getElementById('postId' + index).value;
 
-                fetch(`/mypage/match/${reviewerId}/complete/${postId}/${revieweeId}?rating=${rating}`, {
+                fetch(`/mypage/match/${reviewerId}/complete/${postId}/${revieweeId}?rating=${rating.value}`, {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json',

--- a/src/main/resources/templates/user/review-list.html
+++ b/src/main/resources/templates/user/review-list.html
@@ -2,7 +2,7 @@
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
-    <title>알림 설정</title>
+    <title>평가 목록</title>
     <link rel="stylesheet" href="/css/user/review-list.css">
 </head>
 <body>

--- a/src/main/resources/templates/user/review-list.html
+++ b/src/main/resources/templates/user/review-list.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>알림 설정</title>
+    <link rel="stylesheet" href="/css/user/review-list.css">
+</head>
+<body>
+<div class="container">
+    <div th:replace="~{fragments/header :: header}"></div>
+
+    <div class="title-container">
+        <h1>평가 목록</h1>
+    </div>
+
+    <div class="review-container">
+        <div class="post-header" th:if="${myReviewee.size() > 0}">
+            <span class="header-image">프로필 이미지</span>
+            <span class="header-nickname">닉네임</span>
+            <span class="header-birth">생년월일</span>
+            <span class="header-mbti">mbti</span>
+            <span class="header-gender">성별</span>
+            <span class="header-review"></span>
+        </div>
+        <div th:each="reviewee, iterStat : ${myReviewee}">
+            <div class="reviewee-img">
+                <img th:src="@{${reviewee.profileImage}}">
+            </div>
+            <p class="reviewee-nickname" th:text="${reviewee.nickname}"></p>
+            <p class="reviewee-birth" th:text="${#temporals.format(reviewee.birth, 'yyyy-MM-dd')}"></p>
+            <p class="reviewee-mbti" th:text="${reviewee.mbti}"></p>
+            <p class="reviewee-gender" th:text="${reviewee.gender.name() == 'MALE' ? '남성' : '여성'}"></p>
+            <div class="reviewee-review">
+                <button class="openReviewPopupBtn" th:if="${!myReviewStatuses.get(iterStat.index)}"
+                        th:data-index="${iterStat.index}"> 평가하기 </button>
+                <span class="disabledPopupBtn" th:if="${myReviewStatuses.get(iterStat.index)}"> 평가완료 </span>
+
+                <input th:id="'reviewerId' + ${iterStat.index}" type="hidden" th:value="${reviewee.reviewerId}">
+                <input th:id="'revieweeId' + ${iterStat.index}" type="hidden" th:value="${reviewee.revieweeId}">
+                <input th:id="'postId' + ${iterStat.index}" type="hidden" th:value="${reviewee.postId}">
+
+<!--                <input th:data-reviewer-id="${reviewee.reviewerId}" type="hidden">-->
+<!--                <input th:data-post-id="${reviewee.postId}" type="hidden">-->
+<!--                <input th:data-reviewee-id="${reviewee.revieweeId}" type="hidden">-->
+            </div>
+
+            <div class="popup" style="display: none;" th:id="'reviewPopup' + ${iterStat.index}">
+                <div class="popup-content">
+                    <span class="close" th:data-index="${iterStat.index}">&times;</span>
+                    <h2 th:text="${reviewee.nickname + '님 평가'}"></h2>
+                    <form th:data-index="${iterStat.index}" class="reviewForm">
+                        <label>평가 점수</label>
+                        <div class="rating-buttons">
+                            <th:block th:each="i : ${#numbers.sequence(1, 10)}">
+                                <input type="radio" th:id="'rating-' + ${i} + '-' + ${iterStat.index}"
+                                       th:name="'rating' + ${iterStat.index}" th:value="${i}">
+                                <label th:for="'rating-' + ${i} + '-' + ${iterStat.index}"
+                                       th:text="${i}"></label>
+                            </th:block>
+                        </div>
+                        <button type="submit" class="submit-btn">제출</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div th:replace="~{fragments/footer :: footer}"></div>
+<script>
+    document.addEventListener('DOMContentLoaded', function() {
+        const openPopup = (index) => {
+            const popup = document.querySelector(`#reviewPopup${index}`);
+            popup.style.display = 'block';
+
+            popup.querySelector('.close').addEventListener('click', () => {
+                popup.style.display = 'none';
+            });
+
+            window.addEventListener('click', (event) => {
+                if (event.target === popup) {
+                    popup.style.display = 'none';
+                }
+            });
+
+            popup.querySelector('.reviewForm').addEventListener('submit', function(event) {
+                event.preventDefault();
+                const rating = this.querySelector(`input[name="rating${index}"]:checked`).value;
+                if (!rating) {
+                    alert("평가 점수를 선택해주세요.");
+                    return;
+                }
+                console.log(rating);
+
+                let reviewerId = document.getElementById('reviewerId' + index).value;
+                let revieweeId = document.getElementById('revieweeId' + index).value;
+                let postId = document.getElementById('postId' + index).value;
+
+                fetch(`/mypage/match/${reviewerId}/complete/${postId}/${revieweeId}?rating=${rating}`, {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/json',
+                    }
+                })
+                    .then(response => {
+                        if (response.ok) {
+                            alert("평가가 완료되었습니다.");
+                            popup.style.display = 'none';
+                            location.reload(); // 페이지 갱신
+                        } else {
+                            throw new Error('평가 제출 중 오류가 발생했습니다.');
+                        }
+                    })
+                    .catch(error => {
+                        console.error('Error:', error);
+                        alert(error.message);
+                    });
+            });
+        };
+
+        document.querySelectorAll('.openReviewPopupBtn').forEach(button => {
+            button.addEventListener('click', function() {
+                const index = this.getAttribute('data-index');
+                openPopup(index);
+            });
+        });
+    });
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/user/review-list.html
+++ b/src/main/resources/templates/user/review-list.html
@@ -13,6 +13,10 @@
         <h1>평가 목록</h1>
     </div>
 
+    <div class="button-container">
+        <a th:href="@{|/mypage/match/${user.id}/complete|}">내 동행 목록</a>
+    </div>
+
     <div class="review-container">
         <div class="post-header" th:if="${myReviewee.size() > 0}">
             <span class="header-image">프로필 이미지</span>
@@ -33,7 +37,7 @@
             <div class="reviewee-review">
                 <button class="openReviewPopupBtn" th:if="${!myReviewStatuses.get(iterStat.index)}"
                         th:data-index="${iterStat.index}"> 평가하기 </button>
-                <span class="disabledPopupBtn" th:if="${myReviewStatuses.get(iterStat.index)}"> 평가완료 </span>
+                <button class="disabledPopupBtn" th:if="${myReviewStatuses.get(iterStat.index)}" disabled> 평가완료 </button>
 
                 <input th:id="'reviewerId' + ${iterStat.index}" type="hidden" th:value="${reviewee.reviewerId}">
                 <input th:id="'revieweeId' + ${iterStat.index}" type="hidden" th:value="${reviewee.revieweeId}">


### PR DESCRIPTION
## 요약 #90 #75 
- 동행 종료 및 상호평가 로직

## 추가사항
- 동행 종료 버튼 로직(종료 시 채팅인원으로 상호평가 대상 결정)
- 내 동행 목록에서 현재/이전 동행 확인가능
- 이전 동행은 본인 제외 동행유저 평가 가능

## 수정사항
- 본인에게 1대1 채팅은 걸 수 없음

<br>

- [ ✅ ] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ✅ ] 🧹 불필요한 코드는 제거했나요?
- [ ✅ ] 💭 (선택) 이슈는 등록했나요?
- [ ✅ ] 🏷️ 라벨은 등록했나요?
