### PR TITLE
[Refactor]: 헤더 이미지 처리 및 기본 이미지로 변경 가능

### DIFF
--- a/src/main/java/com/inconcert/domain/user/controller/MyPageController.java
+++ b/src/main/java/com/inconcert/domain/user/controller/MyPageController.java
@@ -67,6 +67,14 @@ public class MyPageController {
         return "redirect:/mypage";
     }
 
+    // 기본 프로필로 변경
+    @PostMapping("/reset-profile-image")
+    @ResponseBody
+    public ResponseEntity<Void> resetProfileImage() {
+        myPageService.resetToDefaultProfileImage();
+        return ResponseEntity.ok().build();
+    }
+
     @GetMapping("/board/{userId}")
     public String showMyPosts(Model model,
                               @PathVariable("userId") Long userId,

--- a/src/main/java/com/inconcert/domain/user/controller/UserController.java
+++ b/src/main/java/com/inconcert/domain/user/controller/UserController.java
@@ -1,6 +1,5 @@
 package com.inconcert.domain.user.controller;
 
-import com.inconcert.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -8,8 +7,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 @Controller
 @RequiredArgsConstructor
 public class UserController {
-    private final UserService userService;
-
     @GetMapping("/loginform")
     public String loginform() {
         return "/loginform";

--- a/src/main/java/com/inconcert/domain/user/entity/Mbti.java
+++ b/src/main/java/com/inconcert/domain/user/entity/Mbti.java
@@ -1,5 +1,5 @@
 package com.inconcert.domain.user.entity;
 
 public enum Mbti {
-    INTJ, INTP, ENTJ, ENTP, INFJ, INFP, ENFJ, ENFP, ISTJ, ISFJ, ESTJ, ESFJ, ISTP, ISFP, ESTP, ESFP
+    INTJ, INTP, ENTJ, ENTP, INFJ, INFP, ENFJ, ENFP, ISTJ, ISFJ, ESTJ, ESFJ, ISTP, ISFP, ESTP, ESFP, 미선택
 }

--- a/src/main/java/com/inconcert/domain/user/entity/User.java
+++ b/src/main/java/com/inconcert/domain/user/entity/User.java
@@ -129,8 +129,8 @@ public class User {
 
     public void updateBanDate(LocalDate newBanDate) {this.banDate = newBanDate;}
 
-    public void setBasicImage(String profileImage) {
-        this.profileImage = profileImage;
+    public void setBasicImage() {
+        this.profileImage = "/images/profile.png";
     }
 
     // 유저 정보 수정

--- a/src/main/java/com/inconcert/domain/user/entity/User.java
+++ b/src/main/java/com/inconcert/domain/user/entity/User.java
@@ -129,6 +129,10 @@ public class User {
 
     public void updateBanDate(LocalDate newBanDate) {this.banDate = newBanDate;}
 
+    public void setBasicImage(String profileImage) {
+        this.profileImage = profileImage;
+    }
+
     // 유저 정보 수정
     public void updateUser(MyPageEditReqDto reqDto, String password, String profileImageUrl) {
         this.nickname = reqDto.getNickname();

--- a/src/main/java/com/inconcert/domain/user/service/MyPageService.java
+++ b/src/main/java/com/inconcert/domain/user/service/MyPageService.java
@@ -78,6 +78,18 @@ public class MyPageService {
         userRepository.save(user);
     }
 
+    // 기본 이미지로 변경
+    @Transactional
+    public void resetToDefaultProfileImage() {
+        User user = userService.getAuthenticatedUser()
+                .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+
+        String defaultProfileImageUrl = "/images/profile.png";
+
+        user.setBasicImage(defaultProfileImageUrl);
+        userRepository.save(user);
+    }
+
     // 동행중
     public Page<MatchRspDTO> presentMatch(Long userId, int page, int size){
         Pageable pageable = PageRequest.of(page, size);

--- a/src/main/java/com/inconcert/domain/user/service/MyPageService.java
+++ b/src/main/java/com/inconcert/domain/user/service/MyPageService.java
@@ -84,9 +84,7 @@ public class MyPageService {
         User user = userService.getAuthenticatedUser()
                 .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
 
-        String defaultProfileImageUrl = "/images/profile.png";
-
-        user.setBasicImage(defaultProfileImageUrl);
+        user.setBasicImage();
         userRepository.save(user);
     }
 

--- a/src/main/java/com/inconcert/global/auth/CustomOAuth2UserService.java
+++ b/src/main/java/com/inconcert/global/auth/CustomOAuth2UserService.java
@@ -6,6 +6,7 @@ import com.inconcert.domain.user.entity.Gender;
 import com.inconcert.domain.user.entity.Mbti;
 import com.inconcert.domain.user.entity.User;
 import com.inconcert.domain.user.repository.UserRepository;
+import com.inconcert.global.exception.ExceptionMessage;
 import com.inconcert.global.exception.RoleNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
@@ -18,8 +19,6 @@ import java.time.LocalDate;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
@@ -46,49 +45,38 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
         Map<String, String> responseMap = (Map<String, String>) oAuth2User.getAttributes().get("response");
 
+        String username = responseMap.get("id");
         String email = responseMap.get("email");
         String name = responseMap.get("name");
-
-        // 이메일에서 '@' 앞부분 추출
-        String username = extractUsernameFromEmail(email);
+        String gender = responseMap.get("gender");
+        String mobile = responseMap.get("mobile").replace("-", "");
+        LocalDate birth = LocalDate.parse(responseMap.get("birthyear").concat("-" + responseMap.get("birthday")));
 
         userRepository.findByUsername(username)
-                .orElseGet(() -> createUser(username, email, name));
+                .orElseGet(() -> createUser(username, email, name, gender, mobile, birth));
 
         return new CustomNaverUser(username, oAuth2User.getAttributes(), oAuth2User.getAuthorities());
     }
 
-    private User createUser(String username, String email, String name) {
+    private User createUser(String username, String email, String name, String gender, String mobile, LocalDate birth) {
         Set<Role> roles = new HashSet<>();
         roles.add(roleRepository.findByName("ROLE_USER")
-                .orElseThrow(() -> new RoleNotFoundException("Role을 찾을 수 없습니다."))
+                .orElseThrow(() -> new RoleNotFoundException(ExceptionMessage.ROLE_NOT_FOUND.getMessage()))
         );
 
-        // user 테이블 컬럼에서 not null인 요소 기본값으로 지정 후 회원가입 되도록 처리
         User user = User.builder()
                 .username(username)
                 .password("password")   // 소셜 로그인 시 비밀번호 필요하지 않음 (임의로 비밀번호 지정)
                 .email(email)
                 .name(name)
-                .nickname(username)
-                .phoneNumber("010-0000-0000") // 기본으로 저장되는 전화번호
-                .birth(LocalDate.now())
-                .gender(Gender.FEMALE)  // 기본값
-                .mbti(Mbti.INFJ)    // 기본값
+                .nickname("inconcert" + username.substring(0, 8))   // 임시 닉네임
+                .phoneNumber(mobile)
+                .birth(birth)
+                .gender(gender.equals("F") ? Gender.FEMALE : Gender.MALE)
+                .mbti(Mbti.미선택)
                 .roles(roles)
                 .build();
 
         return userRepository.save(user);
-    }
-
-    // 이메일에서 username 정규식 추출
-    private String extractUsernameFromEmail(String email) {
-        String username = null;
-        Pattern pattern = Pattern.compile("^[^@]+");
-        Matcher matcher = pattern.matcher(email);
-        if (matcher.find()) {
-            username = matcher.group();
-        }
-        return username;
     }
 }

--- a/src/main/java/com/inconcert/global/auth/CustomUserDetails.java
+++ b/src/main/java/com/inconcert/global/auth/CustomUserDetails.java
@@ -14,14 +14,16 @@ public class CustomUserDetails implements UserDetails {
     private final String username;
     private final String password;
     private final String email;
+    private final String profileImage;
     private final List<GrantedAuthority> authorities;
 
 
-    public CustomUserDetails(Long id, String username, String password, String email, List<String> roles) {
+    public CustomUserDetails(Long id, String username, String password, String email, String profileImage, List<String> roles) {
         this.id = id;
         this.username = username;
         this.password = password;
         this.email = email;
+        this.profileImage = profileImage;
         this.authorities = roles.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
     }
 
@@ -46,6 +48,10 @@ public class CustomUserDetails implements UserDetails {
 
     public String getEmail() {
         return email;
+    }
+
+    public String getProfileImage() {
+        return profileImage;
     }
 
     @Override

--- a/src/main/java/com/inconcert/global/auth/CustomUserDetailsService.java
+++ b/src/main/java/com/inconcert/global/auth/CustomUserDetailsService.java
@@ -27,6 +27,7 @@ public class CustomUserDetailsService implements UserDetailsService {
                 user.getUsername(),
                 user.getPassword(),
                 user.getEmail(),
+                user.getProfileImage(),
                 user.getRoles().stream().map(Role::getName).collect(Collectors.toList())
         );
     }

--- a/src/main/java/com/inconcert/global/auth/jwt/token/entity/Token.java
+++ b/src/main/java/com/inconcert/global/auth/jwt/token/entity/Token.java
@@ -19,10 +19,10 @@ public class Token {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "access_token_value", nullable = false)
+    @Column(name = "access_token_value", nullable = false, columnDefinition = "longtext")
     private String accessTokenValue;
 
-    @Column(name = "refresh_token_value", nullable = false)
+    @Column(name = "refresh_token_value", nullable = false, columnDefinition = "longtext")
     private String refreshTokenValue;
 
     @Builder

--- a/src/main/java/com/inconcert/global/handler/CustomOAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/inconcert/global/handler/CustomOAuth2AuthenticationFailureHandler.java
@@ -21,8 +21,19 @@ public class CustomOAuth2AuthenticationFailureHandler implements AuthenticationF
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
         log.error("OAuth2 authentication failed", exception);
-        response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(HttpStatus.UNAUTHORIZED.value());
-        response.getWriter().write("{\"error\": \"인증에 실패했습니다. 다시 시도해 주세요.\"}");
+
+        // OAuth2 인증 실패 시 예외 메시지 확인
+        String errorMessage = exception.getMessage();
+
+        // 사용자가 인증을 취소한 경우 home으로 리디이렉션
+        if (errorMessage != null && errorMessage.contains("access_denied")) {
+            redirectStrategy.sendRedirect(request, response, "/home");
+        }
+        // 그 외의 오류에 대해서는 에러 메시지 반환
+        else {
+            response.setContentType("application/json;charset=UTF-8");
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+            response.getWriter().write("{\"error\": \"인증에 실패했습니다. 다시 시도해 주세요.\"}");
+        }
     }
 }

--- a/src/main/java/com/inconcert/global/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/inconcert/global/handler/OAuth2SuccessHandler.java
@@ -8,8 +8,8 @@ import com.inconcert.global.auth.CustomNaverUser;
 import com.inconcert.global.auth.jwt.token.entity.Token;
 import com.inconcert.global.auth.jwt.token.service.TokenService;
 import com.inconcert.global.auth.jwt.util.JwtTokenizer;
+import com.inconcert.global.exception.ExceptionMessage;
 import com.inconcert.global.exception.RoleNotFoundException;
-import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -48,7 +48,7 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
 
             // 기본 역할 가져오기 (ROLE_USER)
             Role userRole = roleRepository.findByName("ROLE_USER")
-                    .orElseThrow(() -> new RoleNotFoundException("기본 역할을 찾을 수 없습니다."));
+                    .orElseThrow(() -> new RoleNotFoundException(ExceptionMessage.ROLE_NOT_FOUND.getMessage()));
 
             // User 객체 생성
             User tokenUser = userRepository.findByUsername(username)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,7 +44,11 @@ spring:
             authorization-grant-type: authorization_code
             scope:
               - name
+              - gender
               - email
+              - mobile
+              - birthday
+              - birthyear
             client-name: Naver
         provider:
           naver:

--- a/src/main/resources/static/css/user/editform.css
+++ b/src/main/resources/static/css/user/editform.css
@@ -234,6 +234,7 @@ header {
     aspect-ratio: 1 / 1;
     border-radius: 20px;
     margin: 20px;
+    cursor: pointer;
 }
 
 .profile-container {
@@ -323,4 +324,19 @@ textarea {
 
 .check-btn:hover {
     background-color: #ddd;
+}
+
+.default-profile-btn {
+    background-color: #00A885;
+    color: white;
+    border: none;
+    border-radius: 10px;
+    padding: 8px 12px;
+    cursor: pointer;
+    margin-left: 20px;
+    margin-top: 10px;
+}
+
+.default-profile-btn:hover {
+    cursor: pointer;
 }

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -56,7 +56,7 @@
                         <img class="notification-img" src="/images/notification.png" alt="No Posts"/>
                     </a>
                     <div class="dropdown">
-                        <img class="profile-img" src="/images/profile.png" alt="No Posts"/>
+                        <img class="profile-img" th:src="${#authentication.principal.profileImage}" alt="No Posts"/>
                         <div class="dropdown-content">
                             <a th:href="@{/mypage}">마이페이지</a>
                             <a sec:authorize="hasRole('ROLE_ADMIN')" th:href="@{/report}">신고 목록</a>

--- a/src/main/resources/templates/user/mypageedit.html
+++ b/src/main/resources/templates/user/mypageedit.html
@@ -45,9 +45,7 @@
                         <label for="email">이메일</label>
                         <input type="email" id="email" name="email" th:value="${user.email}" required
                                oninput="enableCheckEmailBtn()">
-                        <button class="check-btn" type="button" id="checkEmailBtn" onclick="checkEmail()" disabled>중복
-                            확인
-                        </button>
+                        <button class="check-btn" type="button" id="checkEmailBtn" onclick="checkEmail()" disabled>중복 확인</button>
                     </div>
                     <div>
                         <label for="phoneNumber">전화번호</label>
@@ -63,6 +61,7 @@
                                     th:selected="${type == user.mbti}"></option>
                         </select>
                     </div>
+                    <button type="button" class="default-profile-btn" onclick="resetToDefaultProfile()">기본 이미지로 변경</button>
                 </div>
             </div>
             <div>
@@ -81,8 +80,15 @@
 <div th:if="${errorMessage}" th:text="${errorMessage}" class="error-message" style="display:none;"></div>
 
 <script>
+    let isNicknameChecked = false; // 닉네임 중복 확인 여부
+    let isEmailChecked = false; // 이메일 중복 확인 여부
+    let isDefaultProfile = false; // 기본 프로필 이미지 여부
+
+    const initialNickname = document.getElementById('nickname').value;
+    const initialEmail = document.getElementById('email').value;
+
     window.onload = function() {
-        var errorMessageElement = document.querySelector('.error-message');
+        let errorMessageElement = document.querySelector('.error-message');
         if (errorMessageElement && errorMessageElement.textContent.trim() !== "") {
             alert(errorMessageElement.textContent);
         }
@@ -93,22 +99,34 @@
     }
 
     function previewImage(event) {
-        var reader = new FileReader();
+        let reader = new FileReader();
         reader.onload = function () {
-            var output = document.getElementById('profileImagePreview');
+            let output = document.getElementById('profileImagePreview');
             output.src = reader.result;
         };
         reader.readAsDataURL(event.target.files[0]);
     }
 
+    // 닉네임 변경 시 중복 확인 플래그 초기화
+    document.getElementById('nickname').addEventListener('input', function () {
+        isNicknameChecked = false; // 닉네임이 변경되면 중복 확인 필요
+        enableCheckNicknameBtn();
+    });
+
+    // 이메일 변경 시 중복 확인 플래그 초기화
+    document.getElementById('email').addEventListener('input', function () {
+        isEmailChecked = false; // 이메일이 변경되면 중복 확인 필요
+        enableCheckEmailBtn();
+    });
+
     function enableCheckNicknameBtn() {
-        var nickname = document.getElementById('nickname').value;
-        document.getElementById('checkNicknameBtn').disabled = nickname.trim() === "";
+        let nickname = document.getElementById('nickname').value;
+        document.getElementById('checkNicknameBtn').disabled = nickname.trim() === "" || nickname === initialNickname;
     }
 
     function enableCheckEmailBtn() {
-        var email = document.getElementById('email').value;
-        document.getElementById('checkEmailBtn').disabled = email.trim() === "";
+        let email = document.getElementById('email').value;
+        document.getElementById('checkEmailBtn').disabled = email.trim() === "" || email === initialEmail;
     }
 
     function checkNickname() {
@@ -124,8 +142,10 @@
             .then(data => {
                 if (data.code === "SU") {
                     alert('사용 가능한 닉네임입니다.');
+                    isNicknameChecked = true; // 중복 확인 성공
                 } else {
                     alert('이미 존재하는 닉네임입니다.');
+                    isNicknameChecked = false; // 중복 확인 실패
                 }
             })
             .catch(error => console.error('Error:', error));
@@ -144,12 +164,68 @@
             .then(data => {
                 if (data.code === "SU") {
                     alert('사용 가능한 이메일입니다.');
+                    isEmailChecked = true; // 중복 확인 성공
                 } else {
                     alert('이미 존재하는 이메일입니다.');
+                    isEmailChecked = false; // 중복 확인 실패
                 }
             })
             .catch(error => console.error('Error:', error));
     }
+
+    // 기본 프로필 이미지로 변경
+    function resetToDefaultProfile() {
+        const defaultProfileImageUrl = '/images/profile.png'; // 기본 프로필 이미지 경로
+        document.getElementById('profileImagePreview').src = defaultProfileImageUrl;
+        document.getElementById('profileImageInput').value = ''; // 파일 선택 필드 비우기
+
+        isDefaultProfile = true; // 기본 프로필 이미지가 선택됨
+
+        // 서버에 기본 프로필로 변경 요청
+        fetch('/mypage/reset-profile-image', {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+            }
+        })
+            .then(response => {
+                if (response.ok) {
+                    alert('기본 프로필 이미지로 변경되었습니다.');
+                } else {
+                    alert('이미지 변경에 실패했습니다.');
+                }
+            })
+            .catch(error => {
+                console.error('Error:', error);
+                alert('오류가 발생했습니다. 다시 시도해 주세요.');
+            });
+    }
+
+    // 폼 제출 시 기본 프로필 이미지 상태 전송
+    document.querySelector('form').addEventListener('submit', function (e) {
+        // 닉네임 중복 확인이 되지 않았으면 경고 후 제출 방지
+        if (!isNicknameChecked) {
+            alert("닉네임 중복 확인을 해주세요.");
+            e.preventDefault(); // 폼 제출 중지
+            return;
+        }
+
+        // 이메일 중복 확인이 되지 않았으면 경고 후 제출 방지
+        if (!isEmailChecked) {
+            alert("이메일 중복 확인을 해주세요.");
+            e.preventDefault(); // 폼 제출 중지
+            return;
+        }
+
+        // 기본 프로필 이미지 사용 중일 경우 이를 서버에 알림
+        if (isDefaultProfile) {
+            const hiddenInput = document.createElement('input');
+            hiddenInput.type = 'hidden';
+            hiddenInput.name = 'isDefaultProfile';
+            hiddenInput.value = 'true';
+            this.appendChild(hiddenInput);
+        }
+    });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## 요약 #2 #27 
- 헤더 이미지 처리 및 기본 이미지로 변경 가능

## 추가사항
- 네이버 로그인 시 받아오는 정보 추가

## 수정사항
- 로그인 시 profileImage를 받아와서 헤더에서 처리
- 토큰 값이 긴 것을 대비해 longtext로 변경
- 마이페이지에서 기본 프로필 이미지로 변경 가능

<br>

- [ ✅ ] 🔀 PR 제목의 형식을 잘 작성했나요? e.g. `[Feat] PR 등록`
- [ ✅ ] 🧹 불필요한 코드는 제거했나요?
- [ ✅ ] 💭 (선택) 이슈는 등록했나요?
- [ ✅ ] 🏷️ 라벨은 등록했나요?