### PR TITLE
[Refactor]: 동행 유저 정보 못불러오는 오류, 회원 탈퇴 시 로직 추가, 글 수정 오류 해결

### DIFF
--- a/src/main/java/com/inconcert/common/service/ImageService.java
+++ b/src/main/java/com/inconcert/common/service/ImageService.java
@@ -2,8 +2,7 @@ package com.inconcert.common.service;
 
 import com.inconcert.common.exception.ExceptionMessage;
 import lombok.RequiredArgsConstructor;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -21,9 +20,8 @@ import java.util.regex.Pattern;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ImageService {
-
-    private static final Logger log = LoggerFactory.getLogger(ImageService.class);
     @Value("${aws.s3.bucket}")
     String bucketName;
 

--- a/src/main/java/com/inconcert/domain/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/inconcert/domain/chat/repository/ChatRoomRepository.java
@@ -62,7 +62,7 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     int findChatRoomsWithNoPostAndBothUsers(@Param("userId1") Long userId1, @Param("userId2") Long userId2);
 
     // 동행 완료 버튼 클릭 시, 그때의 채팅방 유저들 불러오기
-    @Query("SELECT u.id " +
+    @Query("SELECT u.user.id " +
             "FROM ChatRoom c JOIN c.users u " +
             "WHERE c.post.id = :postId")
     List<Long> findUserIdsByPostId(@Param("postId") Long postId);
@@ -71,6 +71,6 @@ public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     @Query("SELECT new com.inconcert.domain.user.dto.response.MatchRspDTO" +
             "(c.post.id, c.id, c.post.title, c.post.endDate, size(c.users), c.post.matchCount, c.post.isEnd, c.post.thumbnailUrl, c.post.postCategory.category.title, c.post.postCategory.title, c.hostUser.nickname) " +
             "FROM ChatRoom c JOIN c.users u " +
-            "WHERE u.id = :userId AND c.post.isEnd = false")
+            "WHERE u.user.id = :userId AND c.post.isEnd = false")
     Page<MatchRspDTO> getChatRoomDTOsByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/src/main/java/com/inconcert/domain/feedback/entity/Feedback.java
+++ b/src/main/java/com/inconcert/domain/feedback/entity/Feedback.java
@@ -23,12 +23,15 @@ public class Feedback{
     private int point;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewer_id")
     private User reviewer;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "reviewee_id")
     private User reviewee;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
     private Post post;
 
     @Builder

--- a/src/main/java/com/inconcert/domain/feedback/repository/FeedbackRepository.java
+++ b/src/main/java/com/inconcert/domain/feedback/repository/FeedbackRepository.java
@@ -14,4 +14,7 @@ public interface FeedbackRepository extends JpaRepository<Feedback, Long> {
     List<Long> findExistingFeedbacks(@Param("reviewerId") Long reviewerId,
                                      @Param("revieweeIds") List<Long> revieweeIds,
                                      @Param("postId") Long postId);
+
+    @Query("SELECT f.reviewee.id FROM Feedback f WHERE f.reviewer.id = :reviewerId")
+    List<Long> findRevieweeIdsByReviewerId(@Param("reviewerId") Long reviewerId);
 }

--- a/src/main/java/com/inconcert/domain/post/entity/Post.java
+++ b/src/main/java/com/inconcert/domain/post/entity/Post.java
@@ -3,6 +3,7 @@ package com.inconcert.domain.post.entity;
 import com.inconcert.domain.category.entity.PostCategory;
 import com.inconcert.domain.chat.entity.ChatRoom;
 import com.inconcert.domain.comment.entity.Comment;
+import com.inconcert.domain.feedback.entity.Feedback;
 import com.inconcert.domain.like.entity.Like;
 import com.inconcert.domain.notification.entity.Notification;
 import com.inconcert.domain.report.entity.Report;
@@ -71,6 +72,9 @@ public class Post extends BaseEntity {
 
     @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Report> reports = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Feedback> feedbacks = new ArrayList<>();
 
     @OneToOne(mappedBy = "post", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private ChatRoom chatRoom;

--- a/src/main/java/com/inconcert/domain/post/service/EditService.java
+++ b/src/main/java/com/inconcert/domain/post/service/EditService.java
@@ -95,6 +95,8 @@ public class EditService {
                 .notifications(new ArrayList<>(currentPost.getNotifications()))
                 .viewCount(currentPost.getViewCount())
                 .postCategory(postCategory)
+                .reports(currentPost.getReports())
+                .feedbacks(currentPost.getFeedbacks())
                 .build();
 
         savePostToRepository(updatedPost, newCategoryTitle);

--- a/src/main/java/com/inconcert/domain/user/entity/User.java
+++ b/src/main/java/com/inconcert/domain/user/entity/User.java
@@ -4,9 +4,11 @@ import com.inconcert.domain.chat.entity.ChatMessage;
 import com.inconcert.domain.chat.entity.ChatNotification;
 import com.inconcert.domain.chat.entity.ChatRoomUser;
 import com.inconcert.domain.comment.entity.Comment;
+import com.inconcert.domain.feedback.entity.Feedback;
 import com.inconcert.domain.like.entity.Like;
 import com.inconcert.domain.notification.entity.Notification;
 import com.inconcert.domain.post.entity.Post;
+import com.inconcert.domain.report.entity.Report;
 import com.inconcert.domain.user.dto.request.MyPageEditReqDto;
 import com.inconcert.common.auth.jwt.token.entity.Token;
 import jakarta.persistence.*;
@@ -103,6 +105,15 @@ public class User {
 
     @OneToMany(mappedBy = "requestUser", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatNotification> chatNotificationRequests = new ArrayList<>();
+
+    @OneToMany(mappedBy = "reviewer", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Feedback> givenReviews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "reviewee", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Feedback> receivedReviews = new ArrayList<>();
+
+    @OneToMany(mappedBy = "reporter", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Report> reports = new ArrayList<>();
 
     public User(Long id, String username, String email){
         this.id = id;

--- a/src/main/java/com/inconcert/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/inconcert/domain/user/repository/UserRepository.java
@@ -14,13 +14,13 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
+    Optional<User> findByNameAndEmail(String name, String email);
+    Optional<User> findByUsernameAndEmail(String username, String email);
+
     boolean existsByUsername(String username);
     boolean existsByEmail(String email);
     boolean existsByNickname(String nickname);
     boolean existsByPhoneNumber(String phoneNumber);
-
-    Optional<User> findByNameAndEmail(String name, String email);
-    Optional<User> findByUsernameAndEmail(String username, String email);
 
     @Query("SELECT new com.inconcert.domain.user.dto.response.FeedbackRspDTO" +
             "(u.id, u.profileImage, u.nickname, u.birth, u.mbti, u.gender, :userId, :postId) " +
@@ -35,6 +35,4 @@ public interface UserRepository extends JpaRepository<User, Long> {
             "SET u.manner_point = (SELECT ROUND(AVG(f.point), 2) FROM feedbacks f WHERE f.reviewee_id = :revieweeId) " +
             "WHERE u.id = :revieweeId", nativeQuery = true)
     void updateMannerPointByRevieweeId(@Param("revieweeId") Long revieweeId);
-
-
 }

--- a/src/main/java/com/inconcert/domain/user/service/MyPageService.java
+++ b/src/main/java/com/inconcert/domain/user/service/MyPageService.java
@@ -62,8 +62,7 @@ public class MyPageService {
     // 유저 정보 수정
     @Transactional
     public void editUser(MyPageEditReqDto reqDto) {
-        User user = userService.getAuthenticatedUser()
-                .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+        User user = getAuthenticatedUser();
 
         // 비밀번호 인코딩
         String encodedPassword = passwordEncoder.encode(reqDto.getPassword());
@@ -87,8 +86,7 @@ public class MyPageService {
     // 기본 이미지로 변경
     @Transactional
     public ResponseEntity<String> resetToDefaultProfileImage() {
-        User user = userService.getAuthenticatedUser()
-                .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
+        User user = getAuthenticatedUser();
 
         // 기존 이미지가 기본 이미지가 아니면 s3 삭제
         if(!user.getProfileImage().equals("/images/profile.png")) {
@@ -144,5 +142,10 @@ public class MyPageService {
                         .stream()
                         .allMatch(Boolean::booleanValue))
                 .collect(Collectors.toList());
+    }
+
+    private User getAuthenticatedUser(){
+        return userService.getAuthenticatedUser()
+                .orElseThrow(() -> new UserNotFoundException(ExceptionMessage.USER_NOT_FOUND.getMessage()));
     }
 }


### PR DESCRIPTION
## 요약
- 동행 유저 정보 못불러오는 오류, 회원 탈퇴 시 로직 추가, 글 수정 오류 해결

## 추가사항
- 글 수정 시 수정된 게시글에 report, feedback도 같이 추가
- 유저 회원탈퇴시 관련 피드백 삭제 처리 및 동기화
- 회원 탈퇴 시 그 회원이 올렸던 이미지 S3상에서 제거(내용, 프사)

## 수정사항
- 동행중/동행완료 목록에서 유저 Id 제대로 못 불러오던 오류

<br>

- [ ✅ ] 🔀 PR 제목의 형식을 잘 작성했나요?
- [ ✅ ] 🧹 불필요한 코드는 제거했나요?
- [ ✅ ] 🏷️ 라벨은 등록했나요?